### PR TITLE
Add example with 'raw printing' when in 'html' mode.

### DIFF
--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -85,6 +85,9 @@ type
     [Test]
     procedure TestGenPhp;
 
+    [Test]
+    procedure TestHtml;
+
   end;
 
 implementation
@@ -112,6 +115,40 @@ begin
     '<% (* this is '#13#10#13#10'a comment *) %>' + //
     'after ' //
     ));
+end;
+
+procedure TTestTemplate.TestHtml;
+type
+  TRec = record
+    content: string;
+  end;
+var
+  ctx: ITemplateContext;
+  data: TRec;
+begin
+  data.content := 'a < b';
+  // no encoding
+  ctx := Template.Context;
+  Assert.AreEqual('a < b', //
+    Template.Eval(ctx, '<% content %>', data));
+
+  // encoding
+  ctx := Template.Context;
+  ctx.UseHtmlVariableEncoder;
+  Assert.AreEqual('a &lt; b', //
+    Template.Eval(ctx, '<% content %>', data));
+
+  // no encoding - using print
+  ctx := Template.Context;
+  Assert.AreEqual('a < b', //
+    Template.Eval(ctx, '<% print(content) %>', data));
+
+  // mix where print allows for raw output
+  ctx := Template.Context;
+  ctx.UseHtmlVariableEncoder;
+  Assert.AreEqual('a &lt; ba < b', //
+    Template.Eval(ctx, '<% content %><% print(content) %>', data));
+
 end;
 
 procedure TTestTemplate.TestHtmlEncoding;

--- a/src/Sempare.Template.TestInclude.pas
+++ b/src/Sempare.Template.TestInclude.pas
@@ -75,7 +75,6 @@ type
 
 procedure TTestTemplateInclude.TestIncludeData;
 var
-  c: ITemplate;
   ctx: ITemplateContext;
   x: record value: string;
 end;
@@ -103,7 +102,6 @@ begin
   Assert.WillRaise(
     procedure
     var
-      c: ITemplate;
       ctx: ITemplateContext;
       x: record value: string;
     end;


### PR DESCRIPTION
Illustrate ability to raw print if required while html encoding in progress