### PR TITLE
Add missing num() function and allow objects to be referenced in bool exprs

### DIFF
--- a/src/Sempare.Template.Functions.Test.pas
+++ b/src/Sempare.Template.Functions.Test.pas
@@ -64,6 +64,8 @@ type
     [Test]
     procedure TestInt();
     [Test]
+    procedure TestNum();
+    [Test]
     procedure TestSplit();
     [Test]
     procedure TestLowercase();
@@ -158,6 +160,14 @@ begin
   Assert.AreEqual('fail', Template.Eval('<% (match(''b'',''a+'')?''ok'':''fail'') %>'));
   Assert.AreEqual('ok', Template.Eval('<% (match(''aaa'',''a+b*'')?''ok'':''fail'') %>'));
   Assert.AreEqual('ok', Template.Eval('<% (match(''aaaaabbbbb'',''a+b*'')?''ok'':''fail'') %>'));
+end;
+
+procedure TFunctionTest.TestNum;
+begin
+  Assert.AreEqual('123', Template.Eval('<% num(''123'') %>'));
+  Assert.AreEqual('123', Template.Eval('<% num(123) %>'));
+  Assert.AreEqual('123.45', Template.Eval('<% num(123.45) %>'));
+
 end;
 
 procedure TFunctionTest.TestPos;

--- a/src/Sempare.Template.Functions.pas
+++ b/src/Sempare.Template.Functions.pas
@@ -150,6 +150,7 @@ type
     class function DtNow: TDateTime; static;
     class function BoolStr(const AValue: TValue): boolean; static;
     class function Bool(const AValue: TValue): boolean; static;
+    class function Num(const AValue: TValue): extended; static;
     class function Int(const AValue: TValue): integer; static;
     class function Str(const AValue: TValue): string; static;
     class function UCFirst(const AString: string): string; static;
@@ -262,6 +263,11 @@ begin
   exit(TRegex.IsMatch(AValue, ARegex));
 end;
 
+class function TInternalFuntions.Num(const AValue: TValue): extended;
+begin
+  exit(AsNum(AValue));
+end;
+
 class function TInternalFuntions.Uppercase(const AString: string): string;
 begin
   exit(AString.ToUpper());
@@ -273,8 +279,24 @@ begin
 end;
 
 class function TInternalFuntions.TypeOf(const AValue: TValue): string;
+var
+  lmsg: string;
+  lpos: integer;
 begin
-  exit(GRttiContext.GetType(AValue.AsType<TValue>.TypeInfo).QualifiedName);
+  try
+    exit(GRttiContext.GetType(AValue.AsType<TValue>.TypeInfo).QualifiedName);
+  except
+    on e: exception do
+    begin
+      lmsg := e.Message;
+      // a big hacky, but a workaround
+      lpos := lmsg.IndexOf(''' is not declared');
+      if lmsg.StartsWith('Type ''') and (lpos > 0) then
+        exit(copy(lmsg, 7, lpos - 6))
+      else
+        raise e;
+    end;
+  end;
 end;
 
 class function TInternalFuntions.SubStr(const AString: string; AStartOffset: integer; ALength: integer): string;

--- a/src/Sempare.Template.Rtti.pas
+++ b/src/Sempare.Template.Rtti.pas
@@ -350,9 +350,8 @@ begin
     tkDynArray:
       exit(AValue.GetArrayLength > 0);
   else
-    exit(false);
+    exit(true);
   end;
-
 end;
 
 function ArrayAsString(const AValue: TValue): string;


### PR DESCRIPTION
Add Num() as it was documented, but missing.
Allow objects to be referenced in bool conditions. They will return true when not null.
Workaround for TypeOf() when RTTI returns an error that type info cannot be referenced.