### PR TITLE
Fix double free bug on ParseFile.

### DIFF
--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -87,9 +87,12 @@ type
 
     [Test]
     procedure TestList;
-    
+
     [Test]
     procedure TestHtml;
+
+    [Test]
+    procedure TestParseFile;
 
   end;
 
@@ -288,6 +291,14 @@ begin
   ctx := Template.Context;
   ctx.Options := [eoStripRecurringSpaces];
   Assert.AreEqual(' hello world ', Template.Eval(ctx, '  hello   world    '));
+end;
+
+procedure TTestTemplate.TestParseFile;
+var
+  LTemplate : ITemplate;
+begin
+  // main thing is that we have no exception here!
+  ltemplate := Template.ParseFile('..\..\demo\VelocityDemo\velocity\international.velocity');
 end;
 
 procedure TTestTemplate.testPrint;

--- a/src/Sempare.Template.pas
+++ b/src/Sempare.Template.pas
@@ -223,11 +223,7 @@ var
   LFileStream: TFStream;
 begin
   LFileStream := TFStream.Create(AFile, fmOpenRead);
-  try
-    exit(Parse(AContext, LFileStream));
-  finally
-    LFileStream.Free;
-  end;
+  exit(Parse(AContext, LFileStream));
 end;
 
 class function Template.ParseFile(const AFile: string): ITemplate;


### PR DESCRIPTION
The ManageStream option defaults to true, so the stream is always freed.