### PR TITLE
Newline stream writer review

### DIFF
--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -149,11 +149,16 @@ begin
   exit(AChar in WHITESPACE);
 {$WARN WIDECHAR_REDUCED ON}
 end;
-(*
-  function IsNewline(const AChar: char): boolean; inline;
-  begin
-  exit((AChar = #10) or (AChar = #13));
-  end; *)
+
+function IsNewline(const AChar: char): boolean; inline;
+begin
+  exit(AChar = #10);
+end;
+
+function IsCR(const AChar: char): boolean; inline;
+begin
+  exit(AChar = #13);
+end;
 
 { TEvaluationTemplateVisitor }
 
@@ -1009,9 +1014,9 @@ begin
       FLastChar := LChar;
       continue;
     end;
-    if LChar = #10 then
+    if IsNewline(LChar) then
     begin
-      if FLastChar = #13 then
+      if IsCR(FLastChar) then
       begin
         TrimLast;
       end;
@@ -1021,7 +1026,7 @@ begin
       end;
       if not LIgnoreNewline then
       begin
-        if not LStripRecurringNL or (FLastChar <> #10) then
+        if not LStripRecurringNL or IsNewline(FLastChar) then
         begin
           FBuffer.Append(FNL);
           FStartOfLine := true;

--- a/src/Sempare.Template.NewLineOption.Test.pas
+++ b/src/Sempare.Template.NewLineOption.Test.pas
@@ -112,7 +112,7 @@ procedure TTestNewLineOption.TestRecurringNLAndSpaces;
 var
   s: TStringStream;
   w: TNewLineStreamWriter;
-  str:string;
+  str: string;
 begin
   s := TStringStream.Create;
   w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoTrimLines, eoStripRecurringNewlines]);
@@ -120,7 +120,7 @@ begin
     w.Write(#10#10#10#10#10'     hello     '#10#10#10#10'    world   '#10#10#10#10);
   finally
     w.Free;
-    str:=s.datastring;
+    str := s.datastring;
     Assert.AreEqual(#10'hello'#10'world'#10, str);
     s.Free;
   end;
@@ -130,7 +130,7 @@ procedure TTestNewLineOption.TestRecurringOnlyNL;
 var
   s: TStringStream;
   w: TNewLineStreamWriter;
-  str:string;
+  str: string;
 begin
   s := TStringStream.Create;
   w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoStripRecurringNewlines]);
@@ -138,7 +138,7 @@ begin
     w.Write(#10#10#10#10#10'     hello     '#10#10#10#10'    world   '#10#10#10#10);
   finally
     w.Free;
-    str:=s.datastring;
+    str := s.datastring;
     Assert.AreEqual(#10'     hello     '#10'    world   '#10, str);
     s.Free;
   end;
@@ -203,10 +203,9 @@ var
   r: TRec;
   s: string;
 begin
-
   r.Value := 'a value';
   r.description := 'some desc';
-  s := Template.Eval(#$D#$A'Value: <% value %>'#$D#$A'Description: <% description %>'#$D#$A, r);
+  s := Template.Eval(#$D#$A'Value: <% value %>'#$D#$A#$D#$A'Description: <% description %>'#$D#$A, r);
   Assert.AreEqual(#$D#$A'Value: a value'#$D#$A#$D#$A'Description: some desc'#$D#$A, s);
 end;
 

--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -295,10 +295,10 @@ end;
 
 procedure TTestTemplate.TestParseFile;
 var
-  LTemplate : ITemplate;
+  LTemplate: ITemplate;
 begin
   // main thing is that we have no exception here!
-  ltemplate := Template.ParseFile('..\..\demo\VelocityDemo\velocity\international.velocity');
+  LTemplate := Template.ParseFile('..\..\demo\VelocityDemo\velocity\international.velocity');
 end;
 
 procedure TTestTemplate.testPrint;


### PR DESCRIPTION
#37 TNewLineStreamWriter fixed to avoid duplicate CR
#36 Allow context to provide a StreamWriterProvider override property. Defaults to GStreamWriterProvider.