### PR TITLE
Merge release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,35 @@
 
 # ![](./images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 Contact: <info@sempare.ltd>
 
 License: [GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html) or [Sempare Limited Commercial License](./docs/commercial.license.md)
 
 Open Source: https://github.com/sempare/sempare-delphi-template-engine
+
+## Contents
+1. [Introduction](#Introduction)
+2. [Quickstart](#Quickstart)
+3. [Features](#Features)
+4. [Objectives](#Objectives)
+5. [Requirements](#Requirements)
+6. [Installation: GetIt](#Installation__GetIt)
+7. [Installation: Delphinus](#Installation__Delphinus_Support)
+8. [Feedback](#Feedback)
+9. [Statements](./docs/statements.md)
+10. [Expressions](./docs/expressions.md)
+11. [Builtin functions](./docs/builtin-functions.md)
+12. [Custom functions](./docs/custom-functions.md)
+13. [Configuration](./docs/configuration.md)
+14. [Components](./docs/components.md)
+15. [Tricks](./docs/tricks.md)
+16. [Template Patterns](./docs/restrictions.md)
+17. [Internals](./docs/internals.md)
+18. [Restrictions/Limitations/Known Bugs](./docs/restrictions.md)
+19. [Todo](./docs/todo.md)
+20. [License](#License)
 
 ## Introduction
 
@@ -50,25 +72,6 @@ In the example above, you can see that the '<%' start and '%>' end the scripting
 Quick tutorials on [You Tube](https://www.youtube.com/playlist?list=PLjjz4SuVScHreGKEInvrjPtLPMBU6l130). 
 The playlist has a few videos that are very short (most less than a minute - blink and they are done). You can drag the slider in the videos if you miss something or refer to the rest of the documentation. 
 
-## Contents
-1. [Introduction](#Introduction)
-2. [Features](#Features)
-3. [Objectives](#Objectives)
-4. [Requirements](#Requirements)
-5. [Feedback](#Feedback)
-6. [Statements](./docs/statements.md)
-7. [Expressions](./docs/expressions.md)
-8. [Builtin functions](./docs/builtin-functions.md)
-9. [Custom functions](./docs/custom-functions.md)
-10. [Stack Frames](./docs/stack-frames.md)
-11. [Tricks](./docs/tricks.md)
-12. [Configuration](./docs/configuration.md)
-13. [Debugging the script behaviour](./docs/debugging.md)
-14. [Simplified Grammar definition](./docs/simplified-grammar.md)
-15. [Design considerations](./docs/design-considerations.md)
-16. [Internals](./docs/internals.md)
-17. [Restrictions](./docs/restrictions.md)
-18. [Todo](./docs/todo.md)
 
 ## Features
 - statements
@@ -92,7 +95,7 @@ The playlist has a few videos that are very short (most less than a minute - bli
 - lazy template resolution
 - parse time evaluation of expressions/statements
 - allow use of custom encoding (UTF-8 with BOM, UTF-8 without BOM, ASCII, etc)
-- extensibile RTTI interface to easily dereference classes and interfaces (current customisations for IVelocityVariables, TDictionary, TJsonObject)
+- extensibile RTTI interface to easily dereference classes and interfaces (current customisations for ITemplateVariables, TDictionary, TJsonObject)
 
 ## Objectives
 
@@ -124,6 +127,12 @@ Have a look at Sempare.Template.Compiler.inc. The following defines can be defin
 - SEMPARE_TEMPLATE_FIREDAC - to support tests for TDataSet
 - SEMPARE_TEMPLATE_NO_INDY - if Indy is not present. This is used to access an html encoder if TNetEncoding is not available.
 
+## Installation: GetIt
+
+The Sempare Template Engine for Delphi can be installed via the [Embarcadero GetIt manager](https://getitnow.embarcadero.com/?q=sempare&product=rad-studio)
+
+This will add the *src* folder to the search path so you can start working immediately.
+
 ## Installation: Delphinus-Support
 
 The Sempare Template Engine for Delphi can be installed via the [Delphinus](https://github.com/Memnarch/Delphinus) package manager.
@@ -142,7 +151,7 @@ Open __Sempare.Template.Engine.Group.groupproj__ which will include:
      
 - __Sempare.Template.Tester.dproj__
 
-   80+ unit tests
+   100+ unit tests
 
 - __demo\VelocityDemo\Sempare.Template.Demo.dproj__
 
@@ -159,16 +168,22 @@ You can raise issues on [GitHub](https://github.com/sempare/sempare.template) an
 
 Most features have some basic tests in place. If a bug is been discovered, please include a basic test/scenario replicating the issue if possible as this will ease the investigation process.
 
+# Contributions
+
+Please see the [contibution terms and conditions](./docs/CONTRIBUTION.pdf)
+
 # License
 
-The Sempare Template library is dual-licensed. You may choose to use it under the restrictions of the [GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html) at
+The Sempare Template Engien is dual-licensed. You may choose to use it under the restrictions of the [GPL v3.0](https://www.gnu.org/licenses/gpl-3.0.en.html) at
 no cost to you, or you may purchase for user under the [Sempare Limited Commercial License](./docs/commercial.license.md)
 
-A commercial licence grants you the right to use Sempare Template in your own applications, royalty free, and without any requirement to disclose your source code nor any modifications to
-Sempare Templte to any other party. A commercial licence lasts into perpetuity, and entitles you to all future updates, free of charge.
+The dual-licensing scheme allows you to test the library with no restrictions, but subject to the terms of the GPL. A nominal fee is requested to support the maintenance of the library if the product is to be used in commercial products. This support fee binds you to the commercial license, removing any of the GPL restrictions, and allowing you to use the library in your products as you will.
 
-A commercial licence is sold per developer developing applications that use Sempare Template. The initial cost is £35 per developer and includes first year of support.
-For support thereafter, a nominal fee of £15 per developer per year if required (the cost of a few cups of coffee).
+A commercial licence grants you the right to use Sempare Template in your own applications, royalty free, and without any requirement to disclose your source code nor any modifications to
+Sempare Templte to any other party. A commercial licence lasts into perpetuity, and entitles you to all future updates - free of charge.
+
+A commercial licence is provided per developer developing applications that use the Sempare Template Engine. The initial cost is $70 per developer and includes first year of support.
+For support thereafter, at your discretion, a support fee of $30 per developer per year would be appreciated (the cost of a few cups of coffee). Please contact us for site license pricing.
 
 Please send an e-mail to info@sempare.ltd to request an invoice which will contain the bank details.
 

--- a/docs/builtin-functions.md
+++ b/docs/builtin-functions.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Builtin functions
 

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -1,0 +1,56 @@
+# ![](../images/sempare-logo-45px.png) Sempare Template Engine
+
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
+
+## Code Structure
+
+The main entry point is in the _Sempare.Template.pas_.
+
+The Sempare Template Engine has the following files:
+
+__Sempare.Template.AST.pas__
+
+All interfaces used by the parser and evaluation engine are defined in this file.
+
+_ITemplateVisitor_ is also defined (visitor pattern) which is used by the pretty printer and the evaluation engine.
+
+__Sempare.Template.Parser.pas__
+
+This is a recursive descent parser.
+
+__Sempare.Template.Lexer.pas__
+
+The lexical analyser _GetToken()_ will return an _ITemplateSymbol_
+
+_ITemplateSymbol_ has a _TTemplateSymbol_ (an enum matching the various symbol types). It also includes an IPosition.
+
+_IPosition_ includes:
+- filename
+- line
+- position
+
+Note the lexer has two modes:
+- Script Mode
+  - This is where statements are defined between <% and %> 
+- Text Mode 
+  - This is where text appears outside of <% and %>.
+
+__Sempare.Template.Context.pas__
+
+This is where the _TTemplateContext_ is actually defined that implement _ITemplateContext_.
+
+__Sempare.Template.Evaluate.pas__
+
+Contains the template evaluation engine.
+
+__Sempare.Template.PrettyPrint.pas__
+
+Contains the Pretty Printer used for debugging.
+
+__Sempare.Template.Rtti.pas__
+
+This may be useful when defining custom functions that need to operate on TValue variables.
+
+__Sempare.Template.StackFrame.pas__
+
+Defines the stack frame utility used by the evaluation engine.

--- a/docs/commercial.license.md
+++ b/docs/commercial.license.md
@@ -9,8 +9,9 @@ The commercial license for Sempare Template Engine for Delphi gives you the righ
 - sell any number of applications in any quantity without any additional run-time fees required
 
 A commercial licence is sold per developer developing applications that use Sempare Template Engine for Delphi. 
-The initial cost is £35 per developer and includes first year of support. 
-For support thereafter, a nominal fee of £15 per developer per year if required (the cost of a few cups of coffee). 
+The initial cost is $70 per developer and includes first year of support. For support thereafter, at your discretion, 
+a support fee of $30 per developer per year would be appreciated (the cost of a few cups of coffee). Please contact us 
+for site license pricing.
 
 Please send an e-mail to info@sempare.ltd to request an invoice which will contain the bank details.
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Components
 
@@ -16,6 +16,9 @@ Key components of interest that are exposed to you are:
 1. [Template](#Template)
 2. [ITemplateContext](#ITemplateContext)
 3. [ITemplate](#ITemplate)
+
+Initially, some true Delphi Components (based off TComponent) were also provided. See [Design Considerations](./design-considerations.md) for more information.
+
 
 ### Template
 
@@ -127,14 +130,4 @@ The output of the Template parser is an object implementing the ITemplate interf
     var tpl := Template.Parse(ctx, 'this is a template'); 
     writeln(Template.Eval(ctx, tpl));
 ```
-##### Thread Safety
-The Sempare Template Engine should be totally thread safe. There is no shared state besides potential references a shared template context.
 
-Components that should be safe to share are instances of _ITemplateContext_ and _ITemplate_. 
-
-##### Example use case
-
-In a threaded environement like a web server, the following would take place:
-- the context and templates are initialised at startup.
-- templates are mapped to various routes used by various route controllers
-- controller methods would interact with a database service and pass data to the template engine.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Configuration
 
@@ -13,6 +13,7 @@ Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
 - [Custom Variables](#Custom_Variables)
 - [Reusing Templates](#Reusing_Templates)
 - [Dynamic Template Resolution](#Dynamic_Template_Resolution)
+- [Ignoring Whitespace With Multi-Line Statements](#Ignoring_Whitespace_With_Multi_Line_Statements)
 - [Options](#Options)
 
 # Overview
@@ -92,6 +93,34 @@ Templates don't need to be precompiled. They can also be located when being pars
 ctx.TemplateResolver = function(const AContext : ITemplate; const AName : string) : ITemplate
 begin
    result := Template.parse('some template loaded from file...');
+end;
+```
+
+### Ignoring Whitespace With Multi-Line Statements
+
+You may have a template something like:
+```
+	<% for i:=1 to 10 %>
+	<% i %>
+	<% end %>
+```
+
+Now it may be apparent that there will be a lot of newlines. You can minimise this using <| and |> statement start and end tokens.
+```
+	<% for i:=1 to 10 |>  this will be ignored
+	   as will this <| print(i) |> and this
+	and this<| end %>
+```
+
+The start/end statement tokens can be changed using the Context.StartStripToken and Context.EndStripToken
+
+e.g.
+```
+begin
+  var ctx := Template.Context;
+  ctx.StartStripToken := '{~';
+  ctx.EndStripToken := '~}';
+  Assert.IsEqual('hello', Template.Eval(ctx, '{{ print('start') ~}ignore me{~ print('end') }}'));
 end;
 ```
 

--- a/docs/custom-functions.md
+++ b/docs/custom-functions.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Custom functions
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Debugging the script behaviour
 

--- a/docs/design-considerations.md
+++ b/docs/design-considerations.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Design considerations
 
@@ -10,3 +10,16 @@ Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
 ### no bytecode
 
 The evaluation engine is a very simple. This may be considered in future.
+
+### custom statment start/end overrides
+
+No validataion is done currently to ensure that <| and |> matchup. They key is that statement start and end tokens matchup,
+as the | indicator is used to to toggle the flag allowing for content to be output or not.
+
+Similar to <% and %>, <| and |> can be changed to some other tokens. The lexical analyser is fairly simpilistic regarding the handling
+of this override scenario, so it is up to you to ensure that overriding does not conflict with any other symbols.
+
+### No Delphi (TComponent) Components
+
+Some Delphi TComponent based descendents were catered for, but code is currently disabled. The main reason for this is that we didn't
+want the template engine to have to be bound to a visual framework like VCL. However, we may review this if requested. 

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Expressions
 

--- a/docs/fpc.md
+++ b/docs/fpc.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2019 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Free Pascal support
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -1,56 +1,11 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Internals
 
-The main entry point is in the _Sempare.Template.pas_.
-
-The Sempare Template Engine has the following files:
-
-__Sempare.Template.AST.pas__
-
-All interfaces used by the parser and evaluation engine are defined in this file.
-
-_ITemplateVisitor_ is also defined (visitor pattern) which is used by the pretty printer and the evaluation engine.
-
-__Sempare.Template.Parser.pas__
-
-This is a recursive descent parser.
-
-__Sempare.Template.Lexer.pas__
-
-The lexical analyser _GetToken()_ will return an _ITemplateSymbol_
-
-_ITemplateSymbol_ has a _TTemplateSymbol_ (an enum matching the various symbol types). It also includes an IPosition.
-
-_IPosition_ includes:
-- filename
-- line
-- position
-
-Note the lexer has two modes:
-- Script Mode
-  - This is where statements are defined between <% and %> 
-- Text Mode 
-  - This is where text appears outside of <% and %>.
-
-__Sempare.Template.Context.pas__
-
-This is where the _TTemplateContext_ is actually defined that implement _ITemplateContext_.
-
-__Sempare.Template.Evaluate.pas__
-
-Contains the template evaluation engine.
-
-__Sempare.Template.PrettyPrint.pas__
-
-Contains the Pretty Printer used for debugging.
-
-__Sempare.Template.Rtti.pas__
-
-This may be useful when defining custom functions that need to operate on TValue variables.
-
-__Sempare.Template.StackFrame.pas__
-
-Defines the stack frame utility used by the evaluation engine.
+1. [Stack Frames](./stack-frames.md)
+2. [Debugging the script behaviour](./debugging.md)
+3. [Simplified Grammar definition](./simplified-grammar.md)
+4. [Design considerations](./design-considerations.md)
+5. [Code Structure](./code-structure.md)

--- a/docs/parse-time-evaluation.md
+++ b/docs/parse-time-evaluation.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Parse Time Evaluation
 

--- a/docs/restrictions.md
+++ b/docs/restrictions.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Known restrictions / limitations / bugs
 

--- a/docs/simplified-grammar.md
+++ b/docs/simplified-grammar.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) SempareTemplate Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Simplified Grammar definition
 

--- a/docs/stack-frames.md
+++ b/docs/stack-frames.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Stack Frames
 

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Statements
 

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -278,3 +278,5 @@ This would yield something like
   	<tr><td>Col1</td><td>Col2</td></tr>
   </table>
 ```
+
+The _eoAllowIgnoreNL_ must be provided in the Context.Options or via Template.Eval() options.

--- a/docs/template-patterns.md
+++ b/docs/template-patterns.md
@@ -1,0 +1,78 @@
+# ![](../images/sempare-logo-45px.png) Sempare Template Engine
+
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
+
+## Template Patterns
+
+Here are some patterns that may be used when designing templates:
+- Header/Footer
+- Master/Detail
+
+### Header/Footer
+
+In this pattern, you may have a set of templates like the following:
+
+header.tpl:
+```
+<html>
+<header>
+</header>
+<body>
+```
+
+footer.tpl:
+```
+</body>
+</html>
+```
+
+atemplate.tpl:
+```
+<% include('header') %>
+
+<p>my content</p>
+
+<% include('footer') %>
+
+```
+
+This pattern can be used along with a TemplateLoader which can load the templates from whereever they are stored.
+
+### Master/Detail
+
+In this pattern, it may be easier to maintain the header/footer together.
+
+master.tpl:
+```
+<html>
+<header>
+</header>
+<body>
+<% include(page) %>
+</body>
+</html>
+
+```
+
+somepage.tpl:
+```
+<p>my content</p>
+```
+
+In this pattern, you rely on the 'page' variable being passed to the template engine, much like any other variable.
+
+illustrative usage:
+```
+var
+   rec : record
+      page:string;
+      // any other data here
+   end;
+begin
+   // assume ctx.TemplateLoader is defined 
+   rec.page := 'somepage.tpl';
+   
+   var output : string := Template.Eval(masterTpl, rec);
+   writeln(output);
+end;
+```

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,21 +1,10 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Todo
 
 - validation
-  - identify required variables ahead of time where possible.
-- create bindings to data sources like TDataSet, etc...
-- review performance. 
-     
-   I have not done much on this. Probably a few things that can be done better.
-   
-   I spotted something I didn't like in TStreamReader however. It uses a TStringBuffer and when the lexer reads a character, 
-   it results in a Delete(0,1) on the TStringBuffer - resulting in a block move. This stdlib internal should ideally 
-   maintain a read offset into the buffer, and refill the buffer when the offset reaches the end. Will raise something on Embarcadero Quality Portal.
-
-   
-- interactive script debugger (but VelocityDemo can be used to observe output)
-- review freepascal and support for older versions of Delphi
-- review strip recurring spacing post processing
+  - identify required variables ahead of time where possible.#
+- improve custom functions support  
+- review freepascal and support for older versions of Delphi 

--- a/docs/tricks.md
+++ b/docs/tricks.md
@@ -1,6 +1,6 @@
 # ![](../images/sempare-logo-45px.png) Sempare Template Engine
 
-Copyright (c) 2020 [Sempare Limited](http://www.sempare.ltd)
+Copyright (c) 2019-2021 [Sempare Limited](http://www.sempare.ltd)
 
 ## Tricks
 
@@ -33,3 +33,21 @@ abcd
 ### Improving performance on larger templates
 
 A quick win would be to use buffered stream so that characters in the buffer are processed quickly.
+
+### Loading templates dynamically
+
+If you reference templates using the 'include' statement, you can rely on a TemplateResolver to load them if they are not
+defined within the template itself.
+
+e.g. This is illustrative:
+
+```
+  ctx := Template.Context;
+  ctx.TemplateResolver := function(AContext: ITemplateContext; const ATemplate: string): ITemplate
+    var
+    	LStream : TFileStream;
+    begin
+      LStream := TFileStream.Create(ATemplate + '.tpl', fmOpenRead);
+      exit(Template.Parse(AContext, LStream));
+    end;
+```

--- a/src/Sempare.Template.AST.pas
+++ b/src/Sempare.Template.AST.pas
@@ -153,6 +153,8 @@ type
     function GetToken: TTemplateSymbol;
     procedure SetToken(const AToken: TTemplateSymbol);
 
+    function StripWS: boolean;
+
     property Token: TTemplateSymbol read GetToken write SetToken;
     property Position: IPosition read GetPosition;
   end;

--- a/src/Sempare.Template.Context.pas
+++ b/src/Sempare.Template.Context.pas
@@ -125,10 +125,10 @@ type
     function GetStreamWriterProvider: TStreamWriterProvider;
     procedure SetStreamWriterProvider(const AProvider: TStreamWriterProvider);
 
-    function GetScriptEndStripWSToken: string;
-    function GetScriptStartStripWSToken: string;
-    procedure SetScriptEndStripWSToken(const Value: string);
-    procedure SetScriptStartStripWSToken(const Value: string);
+    function GetScriptEndStripToken: string;
+    function GetScriptStartStripToken: string;
+    procedure SetScriptEndStripToken(const Value: string);
+    procedure SetScriptStartStripToken(const Value: string);
 
     property Functions: ITemplateFunctions read GetFunctions write SetFunctions;
     property NewLine: string read GetNewLine write SetNewLine;
@@ -143,8 +143,8 @@ type
     property StartToken: string read GetScriptStartToken write SetScriptStartToken;
     property EndToken: string read GetScriptEndToken write SetScriptEndToken;
 
-    property StartStripWSToken: string read GetScriptStartStripWSToken write SetScriptStartStripWSToken;
-    property EndStripWSToken: string read GetScriptEndStripWSToken write SetScriptEndStripWSToken;
+    property StartStripToken: string read GetScriptStartStripToken write SetScriptStartStripToken;
+    property EndStripToken: string read GetScriptEndStripToken write SetScriptEndStripToken;
 
     property StreamWriterProvider: TStreamWriterProvider read GetStreamWriterProvider write SetStreamWriterProvider;
   end;
@@ -198,8 +198,8 @@ type
     FOptions: TTemplateEvaluationOptions;
     FStartToken: string;
     FEndToken: string;
-    FStartStripWSToken: string;
-    FEndStripWSToken: string;
+    FStartStripToken: string;
+    FEndStripToken: string;
     FEncoding: TEncoding;
     FFunctions: ITemplateFunctions;
     FFunctionsSet: boolean;
@@ -235,10 +235,10 @@ type
     function GetScriptEndToken: string;
     procedure SetScriptEndToken(const AToken: string);
 
-    function GetScriptEndStripWSToken: string;
-    function GetScriptStartStripWSToken: string;
-    procedure SetScriptEndStripWSToken(const Value: string);
-    procedure SetScriptStartStripWSToken(const Value: string);
+    function GetScriptEndStripToken: string;
+    function GetScriptStartStripToken: string;
+    procedure SetScriptEndStripToken(const Value: string);
+    procedure SetScriptStartStripToken(const Value: string);
 
     function GetMaxRunTimeMs: integer;
     procedure SetMaxRunTimeMs(const ATimeMS: integer);
@@ -294,8 +294,8 @@ begin
   SetEncoding(GDefaultEncoding);
   FStartToken := GDefaultOpenTag;
   FEndToken := GDefaultCloseTag;
-  FStartStripWSToken := GDefaultOpenStripWSTag;
-  FEndStripWSToken := GDefaultCloseWSTag;
+  FStartStripToken := GDefaultOpenStripWSTag;
+  FEndStripToken := GDefaultCloseWSTag;
   FTemplates := TDictionary<string, ITemplate>.Create;
   FVariables := TTemplateVariables.Create;
   FFunctions := GFunctions;
@@ -374,9 +374,9 @@ begin
   exit(FVariables);
 end;
 
-function TTemplateContext.GetScriptEndStripWSToken: string;
+function TTemplateContext.GetScriptEndStripToken: string;
 begin
-  exit(FEndStripWSToken);
+  exit(FEndStripToken);
 end;
 
 function TTemplateContext.GetScriptEndToken: string;
@@ -384,9 +384,9 @@ begin
   exit(FEndToken);
 end;
 
-function TTemplateContext.GetScriptStartStripWSToken: string;
+function TTemplateContext.GetScriptStartStripToken: string;
 begin
-  exit(FStartStripWSToken);
+  exit(FStartStripToken);
 end;
 
 function TTemplateContext.GetScriptStartToken: string;
@@ -451,9 +451,9 @@ begin
   FVariableEncoder := AEncoder;
 end;
 
-procedure TTemplateContext.SetScriptEndStripWSToken(const Value: string);
+procedure TTemplateContext.SetScriptEndStripToken(const Value: string);
 begin
-  FEndStripWSToken := Value;
+  FEndStripToken := Value;
 end;
 
 procedure TTemplateContext.SetScriptEndToken(const AToken: string);
@@ -461,9 +461,9 @@ begin
   FEndToken := AToken;
 end;
 
-procedure TTemplateContext.SetScriptStartStripWSToken(const Value: string);
+procedure TTemplateContext.SetScriptStartStripToken(const Value: string);
 begin
-  FStartStripWSToken := Value;
+  FStartStripToken := Value;
 end;
 
 procedure TTemplateContext.SetScriptStartToken(const AToken: string);

--- a/src/Sempare.Template.Context.pas
+++ b/src/Sempare.Template.Context.pas
@@ -125,6 +125,11 @@ type
     function GetStreamWriterProvider: TStreamWriterProvider;
     procedure SetStreamWriterProvider(const AProvider: TStreamWriterProvider);
 
+    function GetScriptEndStripWSToken: string;
+    function GetScriptStartStripWSToken: string;
+    procedure SetScriptEndStripWSToken(const Value: string);
+    procedure SetScriptStartStripWSToken(const Value: string);
+
     property Functions: ITemplateFunctions read GetFunctions write SetFunctions;
     property NewLine: string read GetNewLine write SetNewLine;
     property TemplateResolver: TTemplateResolver read GetTemplateResolver write SetTemplateResolver;
@@ -137,6 +142,10 @@ type
     property Options: TTemplateEvaluationOptions read GetOptions write SetOptions;
     property StartToken: string read GetScriptStartToken write SetScriptStartToken;
     property EndToken: string read GetScriptEndToken write SetScriptEndToken;
+
+    property StartStripWSToken: string read GetScriptStartStripWSToken write SetScriptStartStripWSToken;
+    property EndStripWSToken: string read GetScriptEndStripWSToken write SetScriptEndStripWSToken;
+
     property StreamWriterProvider: TStreamWriterProvider read GetStreamWriterProvider write SetStreamWriterProvider;
   end;
 
@@ -160,6 +169,9 @@ var
   GDefaultEncoding: TEncoding;
   GUTF8WithoutPreambleEncoding: TUTF8WithoutPreambleEncoding;
   GStreamWriterProvider: TStreamWriterProvider;
+
+  GDefaultOpenStripWSTag: string = '<|';
+  GDefaultCloseWSTag: string = '|>';
 
 implementation
 
@@ -186,6 +198,8 @@ type
     FOptions: TTemplateEvaluationOptions;
     FStartToken: string;
     FEndToken: string;
+    FStartStripWSToken: string;
+    FEndStripWSToken: string;
     FEncoding: TEncoding;
     FFunctions: ITemplateFunctions;
     FFunctionsSet: boolean;
@@ -220,6 +234,11 @@ type
     procedure SetScriptStartToken(const AToken: string);
     function GetScriptEndToken: string;
     procedure SetScriptEndToken(const AToken: string);
+
+    function GetScriptEndStripWSToken: string;
+    function GetScriptStartStripWSToken: string;
+    procedure SetScriptEndStripWSToken(const Value: string);
+    procedure SetScriptStartStripWSToken(const Value: string);
 
     function GetMaxRunTimeMs: integer;
     procedure SetMaxRunTimeMs(const ATimeMS: integer);
@@ -275,6 +294,8 @@ begin
   SetEncoding(GDefaultEncoding);
   FStartToken := GDefaultOpenTag;
   FEndToken := GDefaultCloseTag;
+  FStartStripWSToken := GDefaultOpenStripWSTag;
+  FEndStripWSToken := GDefaultCloseWSTag;
   FTemplates := TDictionary<string, ITemplate>.Create;
   FVariables := TTemplateVariables.Create;
   FFunctions := GFunctions;
@@ -353,9 +374,19 @@ begin
   exit(FVariables);
 end;
 
+function TTemplateContext.GetScriptEndStripWSToken: string;
+begin
+  exit(FEndStripWSToken);
+end;
+
 function TTemplateContext.GetScriptEndToken: string;
 begin
   exit(FEndToken);
+end;
+
+function TTemplateContext.GetScriptStartStripWSToken: string;
+begin
+  exit(FStartStripWSToken);
 end;
 
 function TTemplateContext.GetScriptStartToken: string;
@@ -420,9 +451,19 @@ begin
   FVariableEncoder := AEncoder;
 end;
 
+procedure TTemplateContext.SetScriptEndStripWSToken(const Value: string);
+begin
+  FEndStripWSToken := Value;
+end;
+
 procedure TTemplateContext.SetScriptEndToken(const AToken: string);
 begin
   FEndToken := AToken;
+end;
+
+procedure TTemplateContext.SetScriptStartStripWSToken(const Value: string);
+begin
+  FStartStripWSToken := Value;
 end;
 
 procedure TTemplateContext.SetScriptStartToken(const AToken: string);

--- a/src/Sempare.Template.Context.pas
+++ b/src/Sempare.Template.Context.pas
@@ -73,7 +73,10 @@ type
     eoStripRecurringSpaces, //
     eoConvertTabsToSpaces, //
     eoNoDefaultFunctions, //
-    eoRaiseErrorWhenVariableNotFound //
+    eoRaiseErrorWhenVariableNotFound, //
+    eoAllowIgnoreNL, //
+
+    eoInternalUseNewLine //
     );
 
   TTemplateEvaluationOptions = set of TTemplateEvaluationOption;
@@ -429,6 +432,7 @@ end;
 procedure TTemplateContext.SetNewLine(const ANewLine: string);
 begin
   FNewLine := ANewLine;
+  include(FOptions, eoInternalUseNewLine);
 end;
 
 procedure TTemplateContext.SetOptions(const AOptions: TTemplateEvaluationOptions);
@@ -545,7 +549,10 @@ GUTF8WithoutPreambleEncoding := TUTF8WithoutPreambleEncoding.Create;
 GDefaultEncoding := TEncoding.UTF8WithoutBOM;
 GStreamWriterProvider := function(const AStream: TStream; AContext: ITemplateContext): TStreamWriter
   begin
-    exit(TNewLineStreamWriter.Create(AStream, AContext.Encoding, AContext.NewLine, AContext.Options));
+    if (eoTrimLines in AContext.Options) or (eoStripRecurringNewlines in AContext.Options) or (eoAllowIgnoreNL in AContext.Options) or (eoInternalUseNewLine in AContext.Options) then
+      exit(TNewLineStreamWriter.Create(AStream, AContext.Encoding, AContext.NewLine, AContext.Options))
+    else
+      exit(TStreamWriter.Create(AStream, AContext.Encoding));
   end;
 
 finalization

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -1026,7 +1026,7 @@ begin
       end;
       if not LIgnoreNewline then
       begin
-        if not LStripRecurringNL or IsNewline(FLastChar) then
+        if not LStripRecurringNL or not IsNewline(FLastChar) then
         begin
           FBuffer.Append(FNL);
           FStartOfLine := true;

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -54,15 +54,15 @@ type
   TLoopOptions = set of TLoopOption;
 
   TNewLineStreamWriter = class(TStreamWriter)
-  type
-    TNLState = (nlsStartOfLine, nlsHasText, nlsNewLine);
   private
     FOptions: TTemplateEvaluationOptions;
     FNL: string;
-    FState: TNLState;
     FBuffer: TStringBuilder;
     FIgnoreNewline: boolean;
+    FStartOfLine: boolean;
+    FLastChar: char;
     procedure TrimEndOfLine;
+    procedure TrimLast;
     procedure DoWrite();
   public
     constructor Create(const AStream: TStream; const AEncoding: TEncoding; const ANL: string; const AOptions: TTemplateEvaluationOptions);
@@ -77,7 +77,8 @@ type
     FStackFrames: TObjectStack<TStackFrame>;
     FEvalStack: TStack<TValue>;
     FStream: TStream;
-    FStreamWriter: TNewLineStreamWriter;
+    FStreamWriter: TStreamWriter;
+    FIsNLStreamWriter: boolean;
     FLoopOptions: TLoopOptions;
     FContext: ITemplateContext;
     FAllowRootDeref: boolean;
@@ -138,7 +139,7 @@ uses
 {$WARN WIDECHAR_REDUCED OFF}
 
 const
-  WHITESPACE: set of char = [#9, ' ', #13];
+  WHITESPACE: set of char = [#9, ' '];
 
 {$WARN WIDECHAR_REDUCED ON}
 
@@ -152,6 +153,11 @@ end;
 function IsNewline(const AChar: char): boolean; inline;
 begin
   exit(AChar = #10);
+end;
+
+function IsCR(const AChar: char): boolean; inline;
+begin
+  exit(AChar = #13);
 end;
 
 { TEvaluationTemplateVisitor }
@@ -527,7 +533,8 @@ begin
   FContext := AContext;
   FStream := AStream;
 
-  FStreamWriter := TNewLineStreamWriter.Create(FStream, FContext.Encoding, FContext.NEWLINE, FContext.Options);
+  FStreamWriter := FContext.StreamWriterProvider(FStream, FContext);
+  FIsNLStreamWriter := FStreamWriter is TNewLineStreamWriter;
 
   FEvalStack := TStack<TValue>.Create;
   FStackFrames := TObjectStack<TStackFrame>.Create;
@@ -812,13 +819,22 @@ end;
 procedure TEvaluationTemplateVisitor.Visit(AStmt: IProcessTemplateStmt);
 var
   LPrevNewLineState: boolean;
+  LSWriter: TNewLineStreamWriter;
 begin
-  LPrevNewLineState := FStreamWriter.IgnoreNewLine;
-  try
-    FStreamWriter.IgnoreNewLine := not AStmt.AllowNewLine;
+  if FIsNLStreamWriter then
+  begin
+    LSWriter := FStreamWriter as TNewLineStreamWriter;
+    LPrevNewLineState := LSWriter.IgnoreNewLine;
+    try
+      LSWriter.IgnoreNewLine := not AStmt.AllowNewLine;
+      acceptvisitor(AStmt.Container, self);
+    finally
+      LSWriter.IgnoreNewLine := LPrevNewLineState;
+    end;
+  end
+  else
+  begin
     acceptvisitor(AStmt.Container, self);
-  finally
-    FStreamWriter.IgnoreNewLine := LPrevNewLineState;
   end;
 end;
 
@@ -937,7 +953,8 @@ begin
   FBuffer := TStringBuilder.Create;
   FOptions := AOptions;
   FNL := ANL;
-  FState := nlsStartOfLine;
+  FStartOfLine := true;
+  FLastChar := #0;
 end;
 
 destructor TNewLineStreamWriter.Destroy;
@@ -964,68 +981,64 @@ begin
   end;
 end;
 
+procedure TNewLineStreamWriter.TrimLast;
+begin
+  if (FBuffer.length >= 1) then
+  begin
+    FBuffer.length := FBuffer.length - 1;
+    if FBuffer.length = 0 then
+      FLastChar := #0
+    else
+      FLastChar := FBuffer.Chars[FBuffer.length - 1];
+    FStartOfLine := FBuffer.length = 0;
+  end;
+end;
+
 procedure TNewLineStreamWriter.Write(const AString: string);
 var
   LChar: char;
-
-  procedure Append(const ANext: TNLState);
-  begin
-    FBuffer.Append(LChar);
-    FState := ANext;
-  end;
+  LTrimLines: boolean;
+  LStripRecurringNL: boolean;
+  LIgnoreNewline: boolean;
+  LIdx: integer;
 
 begin
-  for LChar in AString do
+  LTrimLines := eoTrimLines in FOptions;
+  LStripRecurringNL := eoStripRecurringNewlines in FOptions;
+  LIgnoreNewline := FIgnoreNewline;
+  for LIdx := 1 to length(AString) do
   begin
-    case FState of
-      nlsStartOfLine:
-        if IsWhitespace(LChar) then
-        begin
-          if not(eoTrimLines in FOptions) then
-            Append(nlsHasText);
-        end
-        else if IsNewline(LChar) then
-        begin
-          if not FIgnoreNewline and not(eoStripRecurringNewlines in FOptions) then
-          begin
-            Append(nlsNewLine);
-            DoWrite();
-          end;
-        end
-        else
-          Append(nlsHasText);
-      nlsHasText:
-        if IsWhitespace(LChar) then
-          Append(nlsHasText)
-        else if IsNewline(LChar) then
-        begin
-          if not FIgnoreNewline then
-          begin
-            TrimEndOfLine();
-            FBuffer.Append(FNL);
-            FState := nlsNewLine;
-            DoWrite();
-          end;
-        end
-        else
-          Append(nlsHasText);
-      nlsNewLine:
-        if IsWhitespace(LChar) then
-        begin
-          if not(eoTrimLines in FOptions) then
-            Append(nlsNewLine);
-        end
-        else if IsNewline(LChar) then
-        begin
-          if not FIgnoreNewline and not(eoStripRecurringNewlines in FOptions) then
-          begin
-            Append(nlsNewLine);
-            DoWrite();
-          end;
-        end
-        else
-          Append(nlsHasText);
+    LChar := AString[LIdx];
+    if IsWhitespace(LChar) and FStartOfLine and LTrimLines then
+    begin
+      FLastChar := LChar;
+      continue;
     end;
+    if IsNewline(LChar) then
+    begin
+      if IsCR(FLastChar) then
+      begin
+        TrimLast;
+      end;
+      if LTrimLines then
+      begin
+        TrimEndOfLine;
+      end;
+      if not LIgnoreNewline then
+      begin
+        if not LStripRecurringNL or IsNewline(FLastChar) then
+        begin
+          FBuffer.Append(FNL);
+          FStartOfLine := true;
+        end;
+      end;
+    end
+    else
+    begin
+      FBuffer.Append(LChar);
+      FStartOfLine := false;
+    end;
+    FLastChar := LChar;
   end;
 end;
 

--- a/src/Sempare.Template.Lexer.pas
+++ b/src/Sempare.Template.Lexer.pas
@@ -102,8 +102,8 @@ type
     FLineOffset: integer;
     FStartScript: string;
     FEndScript: string;
-    FStartStripWSScript: string;
-    FEndStripWSScript: string;
+    FStartStripScript: string;
+    FEndStripScript: string;
     FOptions: TTemplateEvaluationOptions;
     procedure GetInput;
     procedure SwallowInput; // a descriptive helper
@@ -162,8 +162,8 @@ begin
   FOptions := AContext.Options;
   FStartScript := AContext.StartToken;
   FEndScript := AContext.EndToken;
-  FStartStripWSScript := AContext.StartStripWSToken;
-  FEndStripWSScript := AContext.EndStripWSToken;
+  FStartStripScript := AContext.StartStripToken;
+  FEndStripScript := AContext.EndStripToken;
   if length(FStartScript) <> 2 then
     raise ETemplateLexer.Create(SContextStartTokenMustBeTwoCharsLong);
   if length(FEndScript) <> 2 then
@@ -390,15 +390,15 @@ begin
             exit(SimpleToken(vsCOLON));
       else
         begin
-          if CharInSet(FCurrent.Input, [FEndScript[1], FEndStripWSScript[1]]) then
+          if CharInSet(FCurrent.Input, [FEndScript[1], FEndStripScript[1]]) then
           begin
             if FCurrent.Input = FEndScript[1] then
               LEndExpect := FEndScript[2]
             else
-              LEndExpect := FEndStripWSScript[2];
+              LEndExpect := FEndStripScript[2];
             if Expecting(LEndExpect) then
             begin
-              LEndStripWS := FCurrent.Input = FEndStripWSScript[1];
+              LEndStripWS := FCurrent.Input = FEndStripScript[1];
               GetInput;
               if FAccumulator.length > 0 then
               begin
@@ -465,7 +465,7 @@ begin
     GetInput;
   while not FCurrent.Eof do
   begin
-    LIsStartStripWSToken := (FCurrent.Input = FStartStripWSScript[1]) and (FLookahead.Input = FStartStripWSScript[2]);
+    LIsStartStripWSToken := (FCurrent.Input = FStartStripScript[1]) and (FLookahead.Input = FStartStripScript[2]);
     if (FCurrent.Input = FStartScript[1]) and (FLookahead.Input = FStartScript[2]) or LIsStartStripWSToken then
     begin
       Result := ValueToken(VsText);

--- a/src/Sempare.Template.NewLineOption.Test.pas
+++ b/src/Sempare.Template.NewLineOption.Test.pas
@@ -48,6 +48,12 @@ type
     procedure TestRecurringNLAndSpaces;
     [Test]
     procedure TestRecurringOnlyNL;
+    [Test]
+    procedure TestNewLine;
+    [Test]
+    procedure TestNewLineWithCustomStreamWriter;
+    [Test]
+    procedure TestNewLineWithContext;
   end;
 
 implementation
@@ -55,23 +61,67 @@ implementation
 uses
   System.Classes,
   System.SysUtils,
+  Sempare.Template,
   Sempare.Template.Context,
   Sempare.Template.Evaluate;
 
 { TTestNewLineOption }
 
+procedure TTestNewLineOption.TestNewLineWithContext;
+type
+  TRec = record
+    Value: string;
+    description: string;
+  end;
+var
+  r: TRec;
+  s: string;
+  ctx: ITemplateContext;
+begin
+  ctx := Template.Context();
+  ctx.newline := #10;
+  r.Value := 'a value';
+  r.description := 'some desc';
+  s := Template.Eval(ctx, 'Value: <% value %>'#$D#$A'Description: <% description %>', r);
+  Assert.AreEqual('Value: a value'#$A'Description: some desc', s);
+end;
+
+procedure TTestNewLineOption.TestNewLineWithCustomStreamWriter;
+type
+  TRec = record
+    Value: string;
+    description: string;
+  end;
+var
+  r: TRec;
+  s: string;
+  ctx: ITemplateContext;
+begin
+  ctx := Template.Context();
+  ctx.StreamWriterProvider := function(const AStream: TStream; AContext: ITemplateContext): TStreamWriter
+    begin
+      result := TStreamWriter.Create(AStream);
+    end;
+  r.Value := 'a value';
+  r.description := 'some desc';
+  s := Template.Eval(ctx, 'Value: <% value %>'#$D#$A'Description: <% description %>', r);
+  Assert.AreEqual('Value: a value'#$D#$A'Description: some desc', s);
+end;
+
 procedure TTestNewLineOption.TestRecurringNLAndSpaces;
 var
   s: TStringStream;
   w: TNewLineStreamWriter;
+  str: string;
 begin
-  s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, [eoTrimLines, eoStripRecurringNewlines]);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoTrimLines, eoStripRecurringNewlines]);
   try
     w.Write(#10#10#10#10#10'     hello     '#10#10#10#10'    world   '#10#10#10#10);
   finally
     w.Free;
-    Assert.AreEqual('hello'#10'world'#10, s.datastring);
+    str := s.datastring;
+    Assert.AreEqual(#10'hello'#10'world'#10, str);
     s.Free;
   end;
 end;
@@ -80,14 +130,16 @@ procedure TTestNewLineOption.TestRecurringOnlyNL;
 var
   s: TStringStream;
   w: TNewLineStreamWriter;
+  str: string;
 begin
-  s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, [eoStripRecurringNewlines]);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoStripRecurringNewlines]);
   try
     w.Write(#10#10#10#10#10'     hello     '#10#10#10#10'    world   '#10#10#10#10);
   finally
     w.Free;
-    Assert.AreEqual('     hello     '#10'    world   '#10, s.datastring);
+    str := s.datastring;
+    Assert.AreEqual(#10'     hello     '#10'    world   '#10, str);
     s.Free;
   end;
 end;
@@ -96,49 +148,65 @@ procedure TTestNewLineOption.TestRecurringSpaces;
 var
   s: TStringStream;
   w: TNewLineStreamWriter;
-  s2:string;
+  s2: string;
 begin
-  s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, []);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, []);
   try
     w.Write('  '#10#10'  '#10#10);
   finally
     w.Free;
-    s2:=s.datastring;
+    s2 := s.datastring;
     Assert.AreEqual('  '#10#10'  '#10#10, s2);
     s.Free;
   end;
-   s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, [eoTrimLines]);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoTrimLines]);
   try
     w.Write('  '#10#10'  '#10#10);
   finally
     w.Free;
-    s2:=s.datastring;
+    s2 := s.datastring;
     Assert.AreEqual(''#10#10''#10#10, s2);
     s.Free;
   end;
 
-  s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, []);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, []);
   try
     w.Write('     hello     '#10#10'    world   ');
   finally
     w.Free;
-    s2:=s.datastring;
+    s2 := s.datastring;
     Assert.AreEqual('     hello     '#10#10'    world   ', s2);
     s.Free;
   end;
-    s := TStringStream.create;
-  w := TNewLineStreamWriter.create(s, TEncoding.ASCII, #10, [eoTrimLines]);
+  s := TStringStream.Create;
+  w := TNewLineStreamWriter.Create(s, TEncoding.ASCII, #10, [eoTrimLines]);
   try
     w.Write('     hello     '#10#10'    world   ');
   finally
     w.Free;
-    s2:=s.datastring;
+    s2 := s.datastring;
     Assert.AreEqual('hello'#10#10'world', s2);
     s.Free;
   end;
+end;
+
+procedure TTestNewLineOption.TestNewLine;
+type
+  TRec = record
+    Value: string;
+    description: string;
+  end;
+var
+  r: TRec;
+  s: string;
+begin
+  r.Value := 'a value';
+  r.description := 'some desc';
+  s := Template.Eval(#$D#$A'Value: <% value %>'#$D#$A#$D#$A'Description: <% description %>'#$D#$A, r);
+  Assert.AreEqual(#$D#$A'Value: a value'#$D#$A#$D#$A'Description: some desc'#$D#$A, s);
 end;
 
 end.

--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -94,6 +94,9 @@ type
     [Test]
     procedure TestParseFile;
 
+    [Test]
+    procedure TestStripWSScripts;
+
   end;
 
 type
@@ -335,6 +338,15 @@ end;
 procedure TTestTemplate.TestStmts;
 begin
   Assert.AreEqual('1', Template.Eval('<% a := 1; print(a) %>'));
+end;
+
+procedure TTestTemplate.TestStripWSScripts;
+begin
+  Assert.AreEqual('', Template.Eval('<% a := 1 |>2<| a:=3 %>'));
+  Assert.AreEqual('12345678910', Template.Eval('<% for i := 1 to 10 |><%print(i)%><| end %>'));
+  Assert.AreEqual('12345678910', Template.Eval('<% for i := 1 to 10 |>'#13#10'<%print(i)%>'#13#10'<| end %>'));
+  Assert.AreEqual(#$D#$A'1'#$D#$A#$D#$A'2'#$D#$A#$D#$A'3'#$D#$A#$D#$A'4'#$D#$A#$D#$A'5'#$D#$A, Template.Eval('<% for i := 1 to 5 %>'#13#10'<%print(i)%>'#13#10'<% end %>'));
+  Assert.AreEqual('hellomiddleworld', Template.Eval('<% print("hello") |> this should '#13#10'<% print("middle") %>'#13#10' go missing<| print("world")  %>'));
 end;
 
 type

--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -295,10 +295,10 @@ end;
 
 procedure TTestTemplate.TestParseFile;
 var
-  LTemplate : ITemplate;
+  LTemplate: ITemplate;
 begin
   // main thing is that we have no exception here!
-  ltemplate := Template.ParseFile('..\..\demo\VelocityDemo\velocity\international.velocity');
+  LTemplate := Template.ParseFile('..\..\demo\VelocityDemo\velocity\international.velocity');
 end;
 
 procedure TTestTemplate.testPrint;

--- a/src/Sempare.Template.Test.pas
+++ b/src/Sempare.Template.Test.pas
@@ -207,13 +207,11 @@ begin
   end;
 
   LResult := Template.Eval(LString);
-
   Assert.AreEqual(LString, LResult);
 
   LString := '<% ignorenl %>' + LString + '<%end%>';
-  LResult := Template.Eval(LString);
+  LResult := Template.Eval(LString, [eoAllowIgnoreNL]);
   Assert.AreEqual('hello world', LResult);
-
 end;
 
 procedure TTestTemplate.TestIgnoreNL2;
@@ -241,7 +239,7 @@ begin
   Assert.AreEqual(LString, LResult);
 
   LString := '<% ignorenl %>' + LString + '<%end%>';
-  LResult := Template.Eval(LString);
+  LResult := Template.Eval(LString, [eoAllowIgnoreNL]);
   Assert.AreEqual('<table><tr><td>col1</td><td>col2</td></tr></table>', LResult);
 end;
 


### PR DESCRIPTION
1. Fix double free bug on ParseFile
2. TNewLineStreamWriter fixed to handle carriage return correctly
3. Provide Context.StartStripToken and Context.EndStripToken to allow for content to be ignored between template statements
4. Documentation updates
5. Context.Options updated to require eoAllowIgnoreNL if ignorenl statement is to be processed