### PR TITLE
Update docs and improve error messaging for ValueSeparator mismatches

### DIFF
--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
 	"name": "Sempare Template Engine",
 	"description": "Sempare Template Engine for Delphi allows for flexible text manipulation. It can be used for generating email, html, source code, xml, configuration, etc.",
-	"version": "1.6.0",
+	"version": "1.6.2",
 	"homepage": "https://github.com/sempare/sempare-delphi-template-engine",
 	"mainsrc": "./src/",
 	"projects": [],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Copyright (c) 2019-2023 [Sempare Limited](http://www.sempare.ltd)
 - [Dynamic Template Resolution](#Dynamic_Template_Resolution)
 - [Ignoring Whitespace With Multi-Line Statements](#Ignoring_Whitespace_With_Multi_Line_Statements)
 - [Options](#Options)
+- [Localisation of numbers](#Localisation_of_numbers)
 
 # Overview
 
@@ -159,3 +160,22 @@ The template engine allows for the following options:
   - strip any empty lines
 - eoPrettyPrint
   - use to review the parsed structure. output is to the console.
+
+### Localisation of numbers 
+
+Numbers are commonly formatted using comma and decimal point. e.g. 123.45
+
+However, in some regions, such as Germany, it the coma may be preferred. e.g. 123,45
+
+In order to accomodate this, the context configuration has a ValueSeperator and DecimalSeparator. These default based on locale.
+
+The DecimalSeparator may be set to '.' or ','. As a comma is commonly used to separate parameters, if the DecimalSeparator is ',', then the ValueSeparator becomes ';'.
+
+The motivation for the behaviour is say we have:
+```
+<% Add(1.23, 4.56) %>
+```
+When the DecimalSeparator is ',', then the ValueSeparator becomes ';' as illustrated:
+```
+<% Add(1,23; 4,56) %>
+```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -10,3 +10,11 @@ writeln(Template.PrettyPrint(Template.Parse('<%if true%>true<%else%>false<%end%>
 ```
 
 Use the _eoPrettyPrint_ option on the _context_ to enable when evaluating or parsing a template.
+
+## Strange parser errors
+
+Parser errors could come from one of two locations:
+- the lexer - the code that breaks the stream into tokens
+- the parser - the code that validates that the tokens are in the correct order according to the gramatical rules
+
+

--- a/docs/images/stmt_assign.svg
+++ b/docs/images/stmt_assign.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" width="384" height="62" viewBox="0 0 384 62">
+<svg class="railroad-diagram" width="384" height="62" viewBox="0 0 384 62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <g transform="translate(.5 .5)">
 <g>
 <path d="M20 21v20m10 -20v20m-10 -10h20"></path>
@@ -49,4 +49,52 @@
 <path d="M334 31h10"></path>
 <path d="M 344 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
 </g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
 </svg>

--- a/docs/images/stmt_assign.svg
+++ b/docs/images/stmt_assign.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" width="384" height="62" viewBox="0 0 384 62">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M334 31h0"></path>
+<g class="terminal ">
+<path d="M50 31h0"></path>
+<path d="M86 31h0"></path>
+<rect x="50" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="35">&#60;%</text>
+</g>
+<path d="M86 31h10"></path>
+<path d="M96 31h10"></path>
+<g class="non-terminal ">
+<path d="M106 31h0"></path>
+<path d="M150 31h0"></path>
+<rect x="106" y="20" width="44" height="22"></rect>
+<text x="128" y="35">var</text>
+</g>
+<path d="M150 31h10"></path>
+<path d="M160 31h10"></path>
+<g class="terminal ">
+<path d="M170 31h0"></path>
+<path d="M206 31h0"></path>
+<rect x="170" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="188" y="35">:=</text>
+</g>
+<path d="M206 31h10"></path>
+<path d="M216 31h10"></path>
+<g class="non-terminal ">
+<path d="M226 31h0"></path>
+<path d="M278 31h0"></path>
+<rect x="226" y="20" width="52" height="22"></rect>
+<text x="252" y="35">expr</text>
+</g>
+<path d="M278 31h10"></path>
+<path d="M288 31h10"></path>
+<g class="terminal ">
+<path d="M298 31h0"></path>
+<path d="M334 31h0"></path>
+<rect x="298" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="316" y="35">%></text>
+</g>
+</g>
+<path d="M334 31h10"></path>
+<path d="M 344 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+</svg>

--- a/docs/images/stmt_cycle.svg
+++ b/docs/images/stmt_cycle.svg
@@ -1,0 +1,148 @@
+<svg class="railroad-diagram" width="600" height="80" viewBox="0 0 600 80" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 40h10"></path>
+<g>
+<path d="M50 40h0"></path>
+<path d="M550 40h0"></path>
+<g class="terminal ">
+<path d="M50 40h0"></path>
+<path d="M86 40h0"></path>
+<rect x="50" y="29" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="44">&#60;%</text>
+</g>
+<path d="M86 40h10"></path>
+<path d="M96 40h10"></path>
+<g class="terminal ">
+<path d="M106 40h0"></path>
+<path d="M166 40h0"></path>
+<rect x="106" y="29" width="60" height="22" rx="10" ry="10"></rect>
+<text x="136" y="44">cycle</text>
+</g>
+<path d="M166 40h10"></path>
+<path d="M176 40h10"></path>
+<g class="terminal ">
+<path d="M186 40h0"></path>
+<path d="M214 40h0"></path>
+<rect x="186" y="29" width="28" height="22" rx="10" ry="10"></rect>
+<text x="200" y="44">(</text>
+</g>
+<path d="M214 40h10"></path>
+<path d="M224 40h10"></path>
+<g class="non-terminal ">
+<path d="M234 40h0"></path>
+<path d="M286 40h0"></path>
+<rect x="234" y="29" width="52" height="22"></rect>
+<text x="260" y="44">expr</text>
+</g>
+<path d="M286 40h10"></path>
+<g>
+<path d="M296 40h0"></path>
+<path d="M456 40h0"></path>
+<path d="M296 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M316 20h120"></path>
+</g>
+<path d="M436 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path>
+<path d="M296 40h20"></path>
+<g>
+<path d="M316 40h0"></path>
+<path d="M436 40h0"></path>
+<path d="M316 40h10"></path>
+<g>
+<path d="M326 40h0"></path>
+<path d="M426 40h0"></path>
+<g class="terminal ">
+<path d="M326 40h0"></path>
+<path d="M354 40h0"></path>
+<rect x="326" y="29" width="28" height="22" rx="10" ry="10"></rect>
+<text x="340" y="44">,</text>
+</g>
+<path d="M354 40h10"></path>
+<path d="M364 40h10"></path>
+<g class="non-terminal ">
+<path d="M374 40h0"></path>
+<path d="M426 40h0"></path>
+<rect x="374" y="29" width="52" height="22"></rect>
+<text x="400" y="44">expr</text>
+</g>
+</g>
+<path d="M426 40h10"></path>
+<path d="M326 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M326 60h100"></path>
+</g>
+<path d="M426 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M436 40h20"></path>
+</g>
+<path d="M456 40h10"></path>
+<g class="terminal ">
+<path d="M466 40h0"></path>
+<path d="M494 40h0"></path>
+<rect x="466" y="29" width="28" height="22" rx="10" ry="10"></rect>
+<text x="480" y="44">)</text>
+</g>
+<path d="M494 40h10"></path>
+<path d="M504 40h10"></path>
+<g class="terminal ">
+<path d="M514 40h0"></path>
+<path d="M550 40h0"></path>
+<rect x="514" y="29" width="36" height="22" rx="10" ry="10"></rect>
+<text x="532" y="44">%></text>
+</g>
+</g>
+<path d="M550 40h10"></path>
+<path d="M 560 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_extends.svg
+++ b/docs/images/stmt_extends.svg
@@ -1,0 +1,178 @@
+<svg class="railroad-diagram" width="636" height="123" viewBox="0 0 636 123" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 34v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 44h10"></path>
+<g>
+<path d="M50 44h0"></path>
+<path d="M50 44h10"></path>
+<g>
+<path d="M60 44h10"></path>
+<path d="M566 44h10"></path>
+<g class="terminal ">
+<path d="M70 44h0"></path>
+<path d="M106 44h0"></path>
+<rect x="70" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="88" y="48">&#60;%</text>
+</g>
+<path d="M106 44h10"></path>
+<path d="M116 44h10"></path>
+<g class="terminal ">
+<path d="M126 44h0"></path>
+<path d="M202 44h0"></path>
+<rect x="126" y="33" width="76" height="22" rx="10" ry="10"></rect>
+<text x="164" y="48">extends</text>
+</g>
+<path d="M202 44h10"></path>
+<path d="M212 44h10"></path>
+<g class="terminal ">
+<path d="M222 44h0"></path>
+<path d="M250 44h0"></path>
+<rect x="222" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="236" y="48">(</text>
+</g>
+<path d="M250 44h10"></path>
+<path d="M260 44h10"></path>
+<g class="non-terminal ">
+<path d="M270 44h0"></path>
+<path d="M322 44h0"></path>
+<rect x="270" y="33" width="52" height="22"></rect>
+<text x="296" y="48">expr</text>
+</g>
+<path d="M322 44h10"></path>
+<g>
+<path d="M332 44h0"></path>
+<path d="M472 44h0"></path>
+<path d="M332 44a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M352 20h100"></path>
+</g>
+<path d="M452 20a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M332 44h20"></path>
+<g>
+<path d="M352 44h0"></path>
+<path d="M452 44h0"></path>
+<g class="terminal ">
+<path d="M352 44h0"></path>
+<path d="M380 44h0"></path>
+<rect x="352" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="366" y="48">,</text>
+</g>
+<path d="M380 44h10"></path>
+<path d="M390 44h10"></path>
+<g class="non-terminal ">
+<path d="M400 44h0"></path>
+<path d="M452 44h0"></path>
+<rect x="400" y="33" width="52" height="22"></rect>
+<text x="426" y="48">expr</text>
+</g>
+</g>
+<path d="M452 44h20"></path>
+</g>
+<path d="M472 44h10"></path>
+<g class="terminal ">
+<path d="M482 44h0"></path>
+<path d="M510 44h0"></path>
+<rect x="482" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="496" y="48">)</text>
+</g>
+<path d="M510 44h10"></path>
+<path d="M520 44h10"></path>
+<g class="terminal ">
+<path d="M530 44h0"></path>
+<path d="M566 44h0"></path>
+<rect x="530" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="548" y="48">%></text>
+</g>
+</g>
+<path d="M576 44a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-516a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h140"></path>
+<path d="M436 92h140"></path>
+<g class="non-terminal ">
+<path d="M200 92h0"></path>
+<path d="M260 92h0"></path>
+<rect x="200" y="81" width="60" height="22"></rect>
+<text x="230" y="96">block</text>
+</g>
+<path d="M260 92h10"></path>
+<path d="M270 92h10"></path>
+<g class="terminal ">
+<path d="M280 92h0"></path>
+<path d="M316 92h0"></path>
+<rect x="280" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="298" y="96">&#60;%</text>
+</g>
+<path d="M316 92h10"></path>
+<path d="M326 92h10"></path>
+<g class="terminal ">
+<path d="M336 92h0"></path>
+<path d="M380 92h0"></path>
+<rect x="336" y="81" width="44" height="22" rx="10" ry="10"></rect>
+<text x="358" y="96">end</text>
+</g>
+<path d="M380 92h10"></path>
+<path d="M390 92h10"></path>
+<g class="terminal ">
+<path d="M400 92h0"></path>
+<path d="M436 92h0"></path>
+<rect x="400" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="418" y="96">%></text>
+</g>
+</g>
+<path d="M576 92h10"></path>
+<path d="M586 92h0"></path>
+</g>
+<path d="M586 92h10"></path>
+<path d="M 596 92 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_for_in.svg
+++ b/docs/images/stmt_for_in.svg
@@ -1,0 +1,250 @@
+<svg class="railroad-diagram" width="472" height="363" viewBox="0 0 472 363" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h10"></path>
+<path d="M70 31h10"></path>
+<g>
+<path d="M80 31h10"></path>
+<path d="M382 31h10"></path>
+<g class="terminal ">
+<path d="M90 31h0"></path>
+<path d="M126 31h0"></path>
+<rect x="90" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="108" y="35">&#60;%</text>
+</g>
+<path d="M126 31h10"></path>
+<path d="M136 31h10"></path>
+<g class="terminal ">
+<path d="M146 31h0"></path>
+<path d="M190 31h0"></path>
+<rect x="146" y="20" width="44" height="22" rx="10" ry="10"></rect>
+<text x="168" y="35">for</text>
+</g>
+<path d="M190 31h10"></path>
+<path d="M200 31h10"></path>
+<g class="non-terminal ">
+<path d="M210 31h0"></path>
+<path d="M254 31h0"></path>
+<rect x="210" y="20" width="44" height="22"></rect>
+<text x="232" y="35">var</text>
+</g>
+<path d="M254 31h10"></path>
+<path d="M264 31h10"></path>
+<g class="terminal ">
+<path d="M274 31h0"></path>
+<path d="M310 31h0"></path>
+<rect x="274" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="292" y="35">in</text>
+</g>
+<path d="M310 31h10"></path>
+<path d="M320 31h10"></path>
+<g class="non-terminal ">
+<path d="M330 31h0"></path>
+<path d="M382 31h0"></path>
+<rect x="330" y="20" width="52" height="22"></rect>
+<text x="356" y="35">expr</text>
+</g>
+</g>
+<path d="M392 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-312a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 92h66"></path>
+<path d="M326 92h66"></path>
+<path d="M146 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M166 68h140"></path>
+</g>
+<path d="M306 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M146 92h20"></path>
+<g>
+<path d="M166 92h0"></path>
+<path d="M306 92h0"></path>
+<g class="terminal ">
+<path d="M166 92h0"></path>
+<path d="M234 92h0"></path>
+<rect x="166" y="81" width="68" height="22" rx="10" ry="10"></rect>
+<text x="200" y="96">offset</text>
+</g>
+<path d="M234 92h10"></path>
+<path d="M244 92h10"></path>
+<g class="non-terminal ">
+<path d="M254 92h0"></path>
+<path d="M306 92h0"></path>
+<rect x="254" y="81" width="52" height="22"></rect>
+<text x="280" y="96">expr</text>
+</g>
+</g>
+<path d="M306 92h20"></path>
+</g>
+<path d="M392 92a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-312a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 153h47"></path>
+<path d="M345 153h47"></path>
+<g>
+<path d="M127 153h0"></path>
+<path d="M299 153h0"></path>
+<path d="M127 153a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M147 129h132"></path>
+</g>
+<path d="M279 129a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M127 153h20"></path>
+<g>
+<path d="M147 153h0"></path>
+<path d="M279 153h0"></path>
+<g class="terminal ">
+<path d="M147 153h0"></path>
+<path d="M207 153h0"></path>
+<rect x="147" y="142" width="60" height="22" rx="10" ry="10"></rect>
+<text x="177" y="157">limit</text>
+</g>
+<path d="M207 153h10"></path>
+<path d="M217 153h10"></path>
+<g class="non-terminal ">
+<path d="M227 153h0"></path>
+<path d="M279 153h0"></path>
+<rect x="227" y="142" width="52" height="22"></rect>
+<text x="253" y="157">expr</text>
+</g>
+</g>
+<path d="M279 153h20"></path>
+</g>
+<path d="M299 153h10"></path>
+<g class="terminal ">
+<path d="M309 153h0"></path>
+<path d="M345 153h0"></path>
+<rect x="309" y="142" width="36" height="22" rx="10" ry="10"></rect>
+<text x="327" y="157">%></text>
+</g>
+</g>
+<path d="M392 153h10"></path>
+<path d="M402 153h10"></path>
+</g>
+<path d="M412 153a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-352a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 201h80"></path>
+<path d="M332 201h80"></path>
+<path d="M140 201h10"></path>
+<g>
+<path d="M150 201h0"></path>
+<path d="M322 201h0"></path>
+<path d="M150 201h20"></path>
+<g class="non-terminal ">
+<path d="M170 201h36"></path>
+<path d="M266 201h36"></path>
+<rect x="206" y="190" width="60" height="22"></rect>
+<text x="236" y="205">block</text>
+</g>
+<path d="M302 201h20"></path>
+<path d="M150 201a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M170 236h0"></path>
+<path d="M302 236h0"></path>
+<rect x="170" y="225" width="132" height="22" rx="10" ry="10"></rect>
+<text x="236" y="240">&#60;% continue %></text>
+</g>
+<path d="M302 236a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M150 201a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M170 271h12"></path>
+<path d="M290 271h12"></path>
+<rect x="182" y="260" width="108" height="22" rx="10" ry="10"></rect>
+<text x="236" y="275">&#60;% break %></text>
+</g>
+<path d="M302 271a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M322 201h10"></path>
+<path d="M150 201a10 10 0 0 0 -10 10v74a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M150 295h172"></path>
+</g>
+<path d="M322 295a10 10 0 0 0 10 -10v-74a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M412 201a10 10 0 0 1 10 10v87a10 10 0 0 1 -10 10h-352a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 332h98"></path>
+<path d="M314 332h98"></path>
+<g class="terminal ">
+<path d="M158 332h0"></path>
+<path d="M194 332h0"></path>
+<rect x="158" y="321" width="36" height="22" rx="10" ry="10"></rect>
+<text x="176" y="336">&#60;%</text>
+</g>
+<path d="M194 332h10"></path>
+<path d="M204 332h10"></path>
+<g class="terminal ">
+<path d="M214 332h0"></path>
+<path d="M258 332h0"></path>
+<rect x="214" y="321" width="44" height="22" rx="10" ry="10"></rect>
+<text x="236" y="336">end</text>
+</g>
+<path d="M258 332h10"></path>
+<path d="M268 332h10"></path>
+<g class="terminal ">
+<path d="M278 332h0"></path>
+<path d="M314 332h0"></path>
+<rect x="278" y="321" width="36" height="22" rx="10" ry="10"></rect>
+<text x="296" y="336">%></text>
+</g>
+</g>
+<path d="M412 332h10"></path>
+<path d="M422 332h0"></path>
+</g>
+<path d="M422 332h10"></path>
+<path d="M 432 332 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_for_in_event.svg
+++ b/docs/images/stmt_for_in_event.svg
@@ -1,0 +1,293 @@
+<svg class="railroad-diagram" width="508" height="276" viewBox="0 0 508 276" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h48"></path>
+<path d="M400 31h48"></path>
+<g class="terminal ">
+<path d="M108 31h0"></path>
+<path d="M144 31h0"></path>
+<rect x="108" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="126" y="35">&#60;%</text>
+</g>
+<path d="M144 31h10"></path>
+<path d="M154 31h10"></path>
+<g class="terminal ">
+<path d="M164 31h0"></path>
+<path d="M208 31h0"></path>
+<rect x="164" y="20" width="44" height="22" rx="10" ry="10"></rect>
+<text x="186" y="35">for</text>
+</g>
+<path d="M208 31h10"></path>
+<path d="M218 31h10"></path>
+<g class="non-terminal ">
+<path d="M228 31h0"></path>
+<path d="M272 31h0"></path>
+<rect x="228" y="20" width="44" height="22"></rect>
+<text x="250" y="35">var</text>
+</g>
+<path d="M272 31h10"></path>
+<path d="M282 31h10"></path>
+<g class="terminal ">
+<path d="M292 31h0"></path>
+<path d="M328 31h0"></path>
+<rect x="292" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="310" y="35">in</text>
+</g>
+<path d="M328 31h10"></path>
+<path d="M338 31h10"></path>
+<g class="non-terminal ">
+<path d="M348 31h0"></path>
+<path d="M400 31h0"></path>
+<rect x="348" y="20" width="52" height="22"></rect>
+<text x="374" y="35">expr</text>
+</g>
+</g>
+<path d="M448 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h0"></path>
+<path d="M448 92h0"></path>
+<path d="M60 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M80 68h348"></path>
+</g>
+<path d="M428 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M60 92h20"></path>
+<g>
+<path d="M80 92h0"></path>
+<path d="M428 92h0"></path>
+<path d="M80 92h20"></path>
+<g>
+<path d="M100 92h20"></path>
+<path d="M388 92h20"></path>
+<g class="terminal ">
+<path d="M120 92h0"></path>
+<path d="M156 92h0"></path>
+<rect x="120" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="96">&#60;%</text>
+</g>
+<path d="M156 92h10"></path>
+<path d="M166 92h10"></path>
+<g class="terminal ">
+<path d="M176 92h0"></path>
+<path d="M252 92h0"></path>
+<rect x="176" y="81" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="96">onbegin</text>
+</g>
+<path d="M252 92h10"></path>
+<path d="M262 92h10"></path>
+<g class="terminal ">
+<path d="M272 92h0"></path>
+<path d="M308 92h0"></path>
+<rect x="272" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="96">%></text>
+</g>
+<path d="M308 92h10"></path>
+<path d="M318 92h10"></path>
+<g class="non-terminal ">
+<path d="M328 92h0"></path>
+<path d="M388 92h0"></path>
+<rect x="328" y="81" width="60" height="22"></rect>
+<text x="358" y="96">block</text>
+</g>
+</g>
+<path d="M408 92h20"></path>
+<path d="M80 92a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 127h28"></path>
+<path d="M380 127h28"></path>
+<g class="terminal ">
+<path d="M128 127h0"></path>
+<path d="M164 127h0"></path>
+<rect x="128" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="146" y="131">&#60;%</text>
+</g>
+<path d="M164 127h10"></path>
+<path d="M174 127h10"></path>
+<g class="terminal ">
+<path d="M184 127h0"></path>
+<path d="M244 127h0"></path>
+<rect x="184" y="116" width="60" height="22" rx="10" ry="10"></rect>
+<text x="214" y="131">onend</text>
+</g>
+<path d="M244 127h10"></path>
+<path d="M254 127h10"></path>
+<g class="terminal ">
+<path d="M264 127h0"></path>
+<path d="M300 127h0"></path>
+<rect x="264" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="282" y="131">%></text>
+</g>
+<path d="M300 127h10"></path>
+<path d="M310 127h10"></path>
+<g class="non-terminal ">
+<path d="M320 127h0"></path>
+<path d="M380 127h0"></path>
+<rect x="320" y="116" width="60" height="22"></rect>
+<text x="350" y="131">block</text>
+</g>
+</g>
+<path d="M408 127a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 162h0"></path>
+<path d="M408 162h0"></path>
+<g class="terminal ">
+<path d="M100 162h0"></path>
+<path d="M136 162h0"></path>
+<rect x="100" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="118" y="166">&#60;%</text>
+</g>
+<path d="M136 162h10"></path>
+<path d="M146 162h10"></path>
+<g class="terminal ">
+<path d="M156 162h0"></path>
+<path d="M272 162h0"></path>
+<rect x="156" y="151" width="116" height="22" rx="10" ry="10"></rect>
+<text x="214" y="166">betweenitems</text>
+</g>
+<path d="M272 162h10"></path>
+<path d="M282 162h10"></path>
+<g class="terminal ">
+<path d="M292 162h0"></path>
+<path d="M328 162h0"></path>
+<rect x="292" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="310" y="166">%></text>
+</g>
+<path d="M328 162h10"></path>
+<path d="M338 162h10"></path>
+<g class="non-terminal ">
+<path d="M348 162h0"></path>
+<path d="M408 162h0"></path>
+<rect x="348" y="151" width="60" height="22"></rect>
+<text x="378" y="166">block</text>
+</g>
+</g>
+<path d="M408 162a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v85a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 197h20"></path>
+<path d="M388 197h20"></path>
+<g class="terminal ">
+<path d="M120 197h0"></path>
+<path d="M156 197h0"></path>
+<rect x="120" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="201">&#60;%</text>
+</g>
+<path d="M156 197h10"></path>
+<path d="M166 197h10"></path>
+<g class="terminal ">
+<path d="M176 197h0"></path>
+<path d="M252 197h0"></path>
+<rect x="176" y="186" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="201">onempty</text>
+</g>
+<path d="M252 197h10"></path>
+<path d="M262 197h10"></path>
+<g class="terminal ">
+<path d="M272 197h0"></path>
+<path d="M308 197h0"></path>
+<rect x="272" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="201">%></text>
+</g>
+<path d="M308 197h10"></path>
+<path d="M318 197h10"></path>
+<g class="non-terminal ">
+<path d="M328 197h0"></path>
+<path d="M388 197h0"></path>
+<rect x="328" y="186" width="60" height="22"></rect>
+<text x="358" y="201">block</text>
+</g>
+</g>
+<path d="M408 197a10 10 0 0 0 10 -10v-85a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M428 92h20"></path>
+</g>
+<path d="M448 92a10 10 0 0 1 10 10v109a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 245h116"></path>
+<path d="M332 245h116"></path>
+<g class="terminal ">
+<path d="M176 245h0"></path>
+<path d="M212 245h0"></path>
+<rect x="176" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="194" y="249">&#60;%</text>
+</g>
+<path d="M212 245h10"></path>
+<path d="M222 245h10"></path>
+<g class="terminal ">
+<path d="M232 245h0"></path>
+<path d="M276 245h0"></path>
+<rect x="232" y="234" width="44" height="22" rx="10" ry="10"></rect>
+<text x="254" y="249">end</text>
+</g>
+<path d="M276 245h10"></path>
+<path d="M286 245h10"></path>
+<g class="terminal ">
+<path d="M296 245h0"></path>
+<path d="M332 245h0"></path>
+<rect x="296" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="314" y="249">%></text>
+</g>
+</g>
+<path d="M448 245h10"></path>
+<path d="M458 245h0"></path>
+</g>
+<path d="M458 245h10"></path>
+<path d="M 468 245 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_for_range.svg
+++ b/docs/images/stmt_for_range.svg
@@ -1,0 +1,296 @@
+<svg class="railroad-diagram" width="600" height="424" viewBox="0 0 600 424" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h10"></path>
+<path d="M70 31h10"></path>
+<g>
+<path d="M80 31h10"></path>
+<path d="M510 31h10"></path>
+<g class="terminal ">
+<path d="M90 31h0"></path>
+<path d="M126 31h0"></path>
+<rect x="90" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="108" y="35">&#60;%</text>
+</g>
+<path d="M126 31h10"></path>
+<path d="M136 31h10"></path>
+<g class="terminal ">
+<path d="M146 31h0"></path>
+<path d="M190 31h0"></path>
+<rect x="146" y="20" width="44" height="22" rx="10" ry="10"></rect>
+<text x="168" y="35">for</text>
+</g>
+<path d="M190 31h10"></path>
+<path d="M200 31h10"></path>
+<g class="non-terminal ">
+<path d="M210 31h0"></path>
+<path d="M254 31h0"></path>
+<rect x="210" y="20" width="44" height="22"></rect>
+<text x="232" y="35">var</text>
+</g>
+<path d="M254 31h10"></path>
+<path d="M264 31h10"></path>
+<g class="terminal ">
+<path d="M274 31h0"></path>
+<path d="M310 31h0"></path>
+<rect x="274" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="292" y="35">:=</text>
+</g>
+<path d="M310 31h10"></path>
+<path d="M320 31h10"></path>
+<g class="non-terminal ">
+<path d="M330 31h0"></path>
+<path d="M382 31h0"></path>
+<rect x="330" y="20" width="52" height="22"></rect>
+<text x="356" y="35">expr</text>
+</g>
+<path d="M382 31h10"></path>
+<path d="M392 31h10"></path>
+<g class="terminal ">
+<path d="M402 31h0"></path>
+<path d="M438 31h0"></path>
+<rect x="402" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="420" y="35">to</text>
+</g>
+<path d="M438 31h10"></path>
+<path d="M448 31h10"></path>
+<g class="non-terminal ">
+<path d="M458 31h0"></path>
+<path d="M510 31h0"></path>
+<rect x="458" y="20" width="52" height="22"></rect>
+<text x="484" y="35">expr</text>
+</g>
+</g>
+<path d="M520 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-440a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 92h138"></path>
+<path d="M382 92h138"></path>
+<path d="M218 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M238 68h124"></path>
+</g>
+<path d="M362 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M218 92h20"></path>
+<g>
+<path d="M238 92h0"></path>
+<path d="M362 92h0"></path>
+<g class="terminal ">
+<path d="M238 92h0"></path>
+<path d="M290 92h0"></path>
+<rect x="238" y="81" width="52" height="22" rx="10" ry="10"></rect>
+<text x="264" y="96">step</text>
+</g>
+<path d="M290 92h10"></path>
+<path d="M300 92h10"></path>
+<g class="non-terminal ">
+<path d="M310 92h0"></path>
+<path d="M362 92h0"></path>
+<rect x="310" y="81" width="52" height="22"></rect>
+<text x="336" y="96">expr</text>
+</g>
+</g>
+<path d="M362 92h20"></path>
+</g>
+<path d="M520 92a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-440a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 153h130"></path>
+<path d="M390 153h130"></path>
+<path d="M210 153a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M230 129h140"></path>
+</g>
+<path d="M370 129a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M210 153h20"></path>
+<g>
+<path d="M230 153h0"></path>
+<path d="M370 153h0"></path>
+<g class="terminal ">
+<path d="M230 153h0"></path>
+<path d="M298 153h0"></path>
+<rect x="230" y="142" width="68" height="22" rx="10" ry="10"></rect>
+<text x="264" y="157">offset</text>
+</g>
+<path d="M298 153h10"></path>
+<path d="M308 153h10"></path>
+<g class="non-terminal ">
+<path d="M318 153h0"></path>
+<path d="M370 153h0"></path>
+<rect x="318" y="142" width="52" height="22"></rect>
+<text x="344" y="157">expr</text>
+</g>
+</g>
+<path d="M370 153h20"></path>
+</g>
+<path d="M520 153a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-440a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 214h111"></path>
+<path d="M409 214h111"></path>
+<g>
+<path d="M191 214h0"></path>
+<path d="M363 214h0"></path>
+<path d="M191 214a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M211 190h132"></path>
+</g>
+<path d="M343 190a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M191 214h20"></path>
+<g>
+<path d="M211 214h0"></path>
+<path d="M343 214h0"></path>
+<g class="terminal ">
+<path d="M211 214h0"></path>
+<path d="M271 214h0"></path>
+<rect x="211" y="203" width="60" height="22" rx="10" ry="10"></rect>
+<text x="241" y="218">limit</text>
+</g>
+<path d="M271 214h10"></path>
+<path d="M281 214h10"></path>
+<g class="non-terminal ">
+<path d="M291 214h0"></path>
+<path d="M343 214h0"></path>
+<rect x="291" y="203" width="52" height="22"></rect>
+<text x="317" y="218">expr</text>
+</g>
+</g>
+<path d="M343 214h20"></path>
+</g>
+<path d="M363 214h10"></path>
+<g class="terminal ">
+<path d="M373 214h0"></path>
+<path d="M409 214h0"></path>
+<rect x="373" y="203" width="36" height="22" rx="10" ry="10"></rect>
+<text x="391" y="218">%></text>
+</g>
+</g>
+<path d="M520 214h10"></path>
+<path d="M530 214h10"></path>
+</g>
+<path d="M540 214a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-480a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 262h144"></path>
+<path d="M396 262h144"></path>
+<path d="M204 262h10"></path>
+<g>
+<path d="M214 262h0"></path>
+<path d="M386 262h0"></path>
+<path d="M214 262h20"></path>
+<g class="non-terminal ">
+<path d="M234 262h36"></path>
+<path d="M330 262h36"></path>
+<rect x="270" y="251" width="60" height="22"></rect>
+<text x="300" y="266">block</text>
+</g>
+<path d="M366 262h20"></path>
+<path d="M214 262a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M234 297h0"></path>
+<path d="M366 297h0"></path>
+<rect x="234" y="286" width="132" height="22" rx="10" ry="10"></rect>
+<text x="300" y="301">&#60;% continue %></text>
+</g>
+<path d="M366 297a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M214 262a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M234 332h12"></path>
+<path d="M354 332h12"></path>
+<rect x="246" y="321" width="108" height="22" rx="10" ry="10"></rect>
+<text x="300" y="336">&#60;% break %></text>
+</g>
+<path d="M366 332a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M386 262h10"></path>
+<path d="M214 262a10 10 0 0 0 -10 10v74a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M214 356h172"></path>
+</g>
+<path d="M386 356a10 10 0 0 0 10 -10v-74a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M540 262a10 10 0 0 1 10 10v87a10 10 0 0 1 -10 10h-480a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 393h162"></path>
+<path d="M378 393h162"></path>
+<g class="terminal ">
+<path d="M222 393h0"></path>
+<path d="M258 393h0"></path>
+<rect x="222" y="382" width="36" height="22" rx="10" ry="10"></rect>
+<text x="240" y="397">&#60;%</text>
+</g>
+<path d="M258 393h10"></path>
+<path d="M268 393h10"></path>
+<g class="terminal ">
+<path d="M278 393h0"></path>
+<path d="M322 393h0"></path>
+<rect x="278" y="382" width="44" height="22" rx="10" ry="10"></rect>
+<text x="300" y="397">end</text>
+</g>
+<path d="M322 393h10"></path>
+<path d="M332 393h10"></path>
+<g class="terminal ">
+<path d="M342 393h0"></path>
+<path d="M378 393h0"></path>
+<rect x="342" y="382" width="36" height="22" rx="10" ry="10"></rect>
+<text x="360" y="397">%></text>
+</g>
+</g>
+<path d="M540 393h10"></path>
+<path d="M550 393h0"></path>
+</g>
+<path d="M550 393h10"></path>
+<path d="M 560 393 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_for_range_event.svg
+++ b/docs/images/stmt_for_range_event.svg
@@ -1,0 +1,293 @@
+<svg class="railroad-diagram" width="508" height="276" viewBox="0 0 508 276" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h48"></path>
+<path d="M400 31h48"></path>
+<g class="terminal ">
+<path d="M108 31h0"></path>
+<path d="M144 31h0"></path>
+<rect x="108" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="126" y="35">&#60;%</text>
+</g>
+<path d="M144 31h10"></path>
+<path d="M154 31h10"></path>
+<g class="terminal ">
+<path d="M164 31h0"></path>
+<path d="M208 31h0"></path>
+<rect x="164" y="20" width="44" height="22" rx="10" ry="10"></rect>
+<text x="186" y="35">for</text>
+</g>
+<path d="M208 31h10"></path>
+<path d="M218 31h10"></path>
+<g class="non-terminal ">
+<path d="M228 31h0"></path>
+<path d="M272 31h0"></path>
+<rect x="228" y="20" width="44" height="22"></rect>
+<text x="250" y="35">var</text>
+</g>
+<path d="M272 31h10"></path>
+<path d="M282 31h10"></path>
+<g class="terminal ">
+<path d="M292 31h0"></path>
+<path d="M328 31h0"></path>
+<rect x="292" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="310" y="35">in</text>
+</g>
+<path d="M328 31h10"></path>
+<path d="M338 31h10"></path>
+<g class="non-terminal ">
+<path d="M348 31h0"></path>
+<path d="M400 31h0"></path>
+<rect x="348" y="20" width="52" height="22"></rect>
+<text x="374" y="35">expr</text>
+</g>
+</g>
+<path d="M448 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h0"></path>
+<path d="M448 92h0"></path>
+<path d="M60 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M80 68h348"></path>
+</g>
+<path d="M428 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M60 92h20"></path>
+<g>
+<path d="M80 92h0"></path>
+<path d="M428 92h0"></path>
+<path d="M80 92h20"></path>
+<g>
+<path d="M100 92h20"></path>
+<path d="M388 92h20"></path>
+<g class="terminal ">
+<path d="M120 92h0"></path>
+<path d="M156 92h0"></path>
+<rect x="120" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="96">&#60;%</text>
+</g>
+<path d="M156 92h10"></path>
+<path d="M166 92h10"></path>
+<g class="terminal ">
+<path d="M176 92h0"></path>
+<path d="M252 92h0"></path>
+<rect x="176" y="81" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="96">onbegin</text>
+</g>
+<path d="M252 92h10"></path>
+<path d="M262 92h10"></path>
+<g class="terminal ">
+<path d="M272 92h0"></path>
+<path d="M308 92h0"></path>
+<rect x="272" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="96">%></text>
+</g>
+<path d="M308 92h10"></path>
+<path d="M318 92h10"></path>
+<g class="non-terminal ">
+<path d="M328 92h0"></path>
+<path d="M388 92h0"></path>
+<rect x="328" y="81" width="60" height="22"></rect>
+<text x="358" y="96">block</text>
+</g>
+</g>
+<path d="M408 92h20"></path>
+<path d="M80 92a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 127h28"></path>
+<path d="M380 127h28"></path>
+<g class="terminal ">
+<path d="M128 127h0"></path>
+<path d="M164 127h0"></path>
+<rect x="128" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="146" y="131">&#60;%</text>
+</g>
+<path d="M164 127h10"></path>
+<path d="M174 127h10"></path>
+<g class="terminal ">
+<path d="M184 127h0"></path>
+<path d="M244 127h0"></path>
+<rect x="184" y="116" width="60" height="22" rx="10" ry="10"></rect>
+<text x="214" y="131">onend</text>
+</g>
+<path d="M244 127h10"></path>
+<path d="M254 127h10"></path>
+<g class="terminal ">
+<path d="M264 127h0"></path>
+<path d="M300 127h0"></path>
+<rect x="264" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="282" y="131">%></text>
+</g>
+<path d="M300 127h10"></path>
+<path d="M310 127h10"></path>
+<g class="non-terminal ">
+<path d="M320 127h0"></path>
+<path d="M380 127h0"></path>
+<rect x="320" y="116" width="60" height="22"></rect>
+<text x="350" y="131">block</text>
+</g>
+</g>
+<path d="M408 127a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 162h0"></path>
+<path d="M408 162h0"></path>
+<g class="terminal ">
+<path d="M100 162h0"></path>
+<path d="M136 162h0"></path>
+<rect x="100" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="118" y="166">&#60;%</text>
+</g>
+<path d="M136 162h10"></path>
+<path d="M146 162h10"></path>
+<g class="terminal ">
+<path d="M156 162h0"></path>
+<path d="M272 162h0"></path>
+<rect x="156" y="151" width="116" height="22" rx="10" ry="10"></rect>
+<text x="214" y="166">betweenitems</text>
+</g>
+<path d="M272 162h10"></path>
+<path d="M282 162h10"></path>
+<g class="terminal ">
+<path d="M292 162h0"></path>
+<path d="M328 162h0"></path>
+<rect x="292" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="310" y="166">%></text>
+</g>
+<path d="M328 162h10"></path>
+<path d="M338 162h10"></path>
+<g class="non-terminal ">
+<path d="M348 162h0"></path>
+<path d="M408 162h0"></path>
+<rect x="348" y="151" width="60" height="22"></rect>
+<text x="378" y="166">block</text>
+</g>
+</g>
+<path d="M408 162a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v85a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 197h20"></path>
+<path d="M388 197h20"></path>
+<g class="terminal ">
+<path d="M120 197h0"></path>
+<path d="M156 197h0"></path>
+<rect x="120" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="201">&#60;%</text>
+</g>
+<path d="M156 197h10"></path>
+<path d="M166 197h10"></path>
+<g class="terminal ">
+<path d="M176 197h0"></path>
+<path d="M252 197h0"></path>
+<rect x="176" y="186" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="201">onempty</text>
+</g>
+<path d="M252 197h10"></path>
+<path d="M262 197h10"></path>
+<g class="terminal ">
+<path d="M272 197h0"></path>
+<path d="M308 197h0"></path>
+<rect x="272" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="201">%></text>
+</g>
+<path d="M308 197h10"></path>
+<path d="M318 197h10"></path>
+<g class="non-terminal ">
+<path d="M328 197h0"></path>
+<path d="M388 197h0"></path>
+<rect x="328" y="186" width="60" height="22"></rect>
+<text x="358" y="201">block</text>
+</g>
+</g>
+<path d="M408 197a10 10 0 0 0 10 -10v-85a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M428 92h20"></path>
+</g>
+<path d="M448 92a10 10 0 0 1 10 10v109a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 245h116"></path>
+<path d="M332 245h116"></path>
+<g class="terminal ">
+<path d="M176 245h0"></path>
+<path d="M212 245h0"></path>
+<rect x="176" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="194" y="249">&#60;%</text>
+</g>
+<path d="M212 245h10"></path>
+<path d="M222 245h10"></path>
+<g class="terminal ">
+<path d="M232 245h0"></path>
+<path d="M276 245h0"></path>
+<rect x="232" y="234" width="44" height="22" rx="10" ry="10"></rect>
+<text x="254" y="249">end</text>
+</g>
+<path d="M276 245h10"></path>
+<path d="M286 245h10"></path>
+<g class="terminal ">
+<path d="M296 245h0"></path>
+<path d="M332 245h0"></path>
+<rect x="296" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="314" y="249">%></text>
+</g>
+</g>
+<path d="M448 245h10"></path>
+<path d="M458 245h0"></path>
+</g>
+<path d="M458 245h10"></path>
+<path d="M 468 245 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_if.svg
+++ b/docs/images/stmt_if.svg
@@ -1,0 +1,225 @@
+<svg class="railroad-diagram" width="672" height="197" viewBox="0 0 672 197" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h38"></path>
+<path d="M398 31h38"></path>
+<g class="terminal ">
+<path d="M98 31h0"></path>
+<path d="M134 31h0"></path>
+<rect x="98" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="116" y="35">&#60;%</text>
+</g>
+<path d="M134 31h10"></path>
+<path d="M144 31h10"></path>
+<g class="terminal ">
+<path d="M154 31h0"></path>
+<path d="M190 31h0"></path>
+<rect x="154" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="172" y="35">if</text>
+</g>
+<path d="M190 31h10"></path>
+<path d="M200 31h10"></path>
+<g class="non-terminal ">
+<path d="M210 31h0"></path>
+<path d="M262 31h0"></path>
+<rect x="210" y="20" width="52" height="22"></rect>
+<text x="236" y="35">expr</text>
+</g>
+<path d="M262 31h10"></path>
+<path d="M272 31h10"></path>
+<g class="terminal ">
+<path d="M282 31h0"></path>
+<path d="M318 31h0"></path>
+<rect x="282" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="300" y="35">%></text>
+</g>
+<path d="M318 31h10"></path>
+<path d="M328 31h10"></path>
+<g class="non-terminal ">
+<path d="M338 31h0"></path>
+<path d="M398 31h0"></path>
+<rect x="338" y="20" width="60" height="22"></rect>
+<text x="368" y="35">block</text>
+</g>
+</g>
+<path d="M436 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-376a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h0"></path>
+<path d="M436 92h0"></path>
+<path d="M60 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M80 68h336"></path>
+</g>
+<path d="M416 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M60 92h20"></path>
+<g>
+<path d="M80 92h0"></path>
+<path d="M416 92h0"></path>
+<path d="M80 92h10"></path>
+<g>
+<path d="M90 92h0"></path>
+<path d="M406 92h0"></path>
+<g class="terminal ">
+<path d="M90 92h0"></path>
+<path d="M126 92h0"></path>
+<rect x="90" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="108" y="96">&#60;%</text>
+</g>
+<path d="M126 92h10"></path>
+<path d="M136 92h10"></path>
+<g class="terminal ">
+<path d="M146 92h0"></path>
+<path d="M198 92h0"></path>
+<rect x="146" y="81" width="52" height="22" rx="10" ry="10"></rect>
+<text x="172" y="96">elif</text>
+</g>
+<path d="M198 92h10"></path>
+<path d="M208 92h10"></path>
+<g class="non-terminal ">
+<path d="M218 92h0"></path>
+<path d="M270 92h0"></path>
+<rect x="218" y="81" width="52" height="22"></rect>
+<text x="244" y="96">expr</text>
+</g>
+<path d="M270 92h10"></path>
+<path d="M280 92h10"></path>
+<g class="terminal ">
+<path d="M290 92h0"></path>
+<path d="M326 92h0"></path>
+<rect x="290" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="308" y="96">%></text>
+</g>
+<path d="M326 92h10"></path>
+<path d="M336 92h10"></path>
+<g class="non-terminal ">
+<path d="M346 92h0"></path>
+<path d="M406 92h0"></path>
+<rect x="346" y="81" width="60" height="22"></rect>
+<text x="376" y="96">block</text>
+</g>
+</g>
+<path d="M406 92h10"></path>
+<path d="M90 92a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M90 116h316"></path>
+</g>
+<path d="M406 116a10 10 0 0 0 10 -10v-4a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M416 92h20"></path>
+</g>
+<path d="M436 92a10 10 0 0 1 10 10v17a10 10 0 0 1 -10 10h-376a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 166h78"></path>
+<path d="M358 166h78"></path>
+<path d="M138 166a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M158 142h180"></path>
+</g>
+<path d="M338 142a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M138 166h20"></path>
+<g>
+<path d="M158 166h0"></path>
+<path d="M338 166h0"></path>
+<g class="terminal ">
+<path d="M158 166h0"></path>
+<path d="M258 166h0"></path>
+<rect x="158" y="155" width="100" height="22" rx="10" ry="10"></rect>
+<text x="208" y="170">&#60;% else %></text>
+</g>
+<path d="M258 166h10"></path>
+<path d="M268 166h10"></path>
+<g class="non-terminal ">
+<path d="M278 166h0"></path>
+<path d="M338 166h0"></path>
+<rect x="278" y="155" width="60" height="22"></rect>
+<text x="308" y="170">block</text>
+</g>
+</g>
+<path d="M338 166h20"></path>
+</g>
+<path d="M436 166h10"></path>
+<path d="M446 166h0"></path>
+</g>
+<path d="M446 166h10"></path>
+<path d="M456 166h10"></path>
+<g class="terminal ">
+<path d="M466 166h0"></path>
+<path d="M502 166h0"></path>
+<rect x="466" y="155" width="36" height="22" rx="10" ry="10"></rect>
+<text x="484" y="170">&#60;%</text>
+</g>
+<path d="M502 166h10"></path>
+<path d="M512 166h10"></path>
+<g class="terminal ">
+<path d="M522 166h0"></path>
+<path d="M566 166h0"></path>
+<rect x="522" y="155" width="44" height="22" rx="10" ry="10"></rect>
+<text x="544" y="170">end</text>
+</g>
+<path d="M566 166h10"></path>
+<path d="M576 166h10"></path>
+<g class="terminal ">
+<path d="M586 166h0"></path>
+<path d="M622 166h0"></path>
+<rect x="586" y="155" width="36" height="22" rx="10" ry="10"></rect>
+<text x="604" y="170">%></text>
+</g>
+<path d="M622 166h10"></path>
+<path d="M 632 166 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_ignorenl.svg
+++ b/docs/images/stmt_ignorenl.svg
@@ -1,0 +1,120 @@
+<svg class="railroad-diagram" width="552" height="62" viewBox="0 0 552 62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M246 31h0"></path>
+<g class="terminal ">
+<path d="M50 31h0"></path>
+<path d="M86 31h0"></path>
+<rect x="50" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="35">&#60;%</text>
+</g>
+<path d="M86 31h10"></path>
+<path d="M96 31h10"></path>
+<g class="terminal ">
+<path d="M106 31h0"></path>
+<path d="M190 31h0"></path>
+<rect x="106" y="20" width="84" height="22" rx="10" ry="10"></rect>
+<text x="148" y="35">ignorenl</text>
+</g>
+<path d="M190 31h10"></path>
+<path d="M200 31h10"></path>
+<g class="terminal ">
+<path d="M210 31h0"></path>
+<path d="M246 31h0"></path>
+<rect x="210" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="228" y="35">%></text>
+</g>
+</g>
+<path d="M246 31h10"></path>
+<path d="M256 31h10"></path>
+<g class="non-terminal ">
+<path d="M266 31h0"></path>
+<path d="M326 31h0"></path>
+<rect x="266" y="20" width="60" height="22"></rect>
+<text x="296" y="35">block</text>
+</g>
+<path d="M326 31h10"></path>
+<path d="M336 31h10"></path>
+<g>
+<path d="M346 31h0"></path>
+<path d="M502 31h0"></path>
+<g class="terminal ">
+<path d="M346 31h0"></path>
+<path d="M382 31h0"></path>
+<rect x="346" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="364" y="35">&#60;%</text>
+</g>
+<path d="M382 31h10"></path>
+<path d="M392 31h10"></path>
+<g class="terminal ">
+<path d="M402 31h0"></path>
+<path d="M446 31h0"></path>
+<rect x="402" y="20" width="44" height="22" rx="10" ry="10"></rect>
+<text x="424" y="35">end</text>
+</g>
+<path d="M446 31h10"></path>
+<path d="M456 31h10"></path>
+<g class="terminal ">
+<path d="M466 31h0"></path>
+<path d="M502 31h0"></path>
+<rect x="466" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="484" y="35">%></text>
+</g>
+</g>
+<path d="M502 31h10"></path>
+<path d="M 512 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_include.svg
+++ b/docs/images/stmt_include.svg
@@ -1,0 +1,178 @@
+<svg class="railroad-diagram" width="636" height="123" viewBox="0 0 636 123" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 34v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 44h10"></path>
+<g>
+<path d="M50 44h0"></path>
+<path d="M50 44h10"></path>
+<g>
+<path d="M60 44h10"></path>
+<path d="M566 44h10"></path>
+<g class="terminal ">
+<path d="M70 44h0"></path>
+<path d="M106 44h0"></path>
+<rect x="70" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="88" y="48">&#60;%</text>
+</g>
+<path d="M106 44h10"></path>
+<path d="M116 44h10"></path>
+<g class="terminal ">
+<path d="M126 44h0"></path>
+<path d="M202 44h0"></path>
+<rect x="126" y="33" width="76" height="22" rx="10" ry="10"></rect>
+<text x="164" y="48">include</text>
+</g>
+<path d="M202 44h10"></path>
+<path d="M212 44h10"></path>
+<g class="terminal ">
+<path d="M222 44h0"></path>
+<path d="M250 44h0"></path>
+<rect x="222" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="236" y="48">(</text>
+</g>
+<path d="M250 44h10"></path>
+<path d="M260 44h10"></path>
+<g class="non-terminal ">
+<path d="M270 44h0"></path>
+<path d="M322 44h0"></path>
+<rect x="270" y="33" width="52" height="22"></rect>
+<text x="296" y="48">expr</text>
+</g>
+<path d="M322 44h10"></path>
+<g>
+<path d="M332 44h0"></path>
+<path d="M472 44h0"></path>
+<path d="M332 44a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M352 20h100"></path>
+</g>
+<path d="M452 20a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M332 44h20"></path>
+<g>
+<path d="M352 44h0"></path>
+<path d="M452 44h0"></path>
+<g class="terminal ">
+<path d="M352 44h0"></path>
+<path d="M380 44h0"></path>
+<rect x="352" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="366" y="48">,</text>
+</g>
+<path d="M380 44h10"></path>
+<path d="M390 44h10"></path>
+<g class="non-terminal ">
+<path d="M400 44h0"></path>
+<path d="M452 44h0"></path>
+<rect x="400" y="33" width="52" height="22"></rect>
+<text x="426" y="48">expr</text>
+</g>
+</g>
+<path d="M452 44h20"></path>
+</g>
+<path d="M472 44h10"></path>
+<g class="terminal ">
+<path d="M482 44h0"></path>
+<path d="M510 44h0"></path>
+<rect x="482" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="496" y="48">)</text>
+</g>
+<path d="M510 44h10"></path>
+<path d="M520 44h10"></path>
+<g class="terminal ">
+<path d="M530 44h0"></path>
+<path d="M566 44h0"></path>
+<rect x="530" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="548" y="48">%></text>
+</g>
+</g>
+<path d="M576 44a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-516a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h140"></path>
+<path d="M436 92h140"></path>
+<g class="non-terminal ">
+<path d="M200 92h0"></path>
+<path d="M260 92h0"></path>
+<rect x="200" y="81" width="60" height="22"></rect>
+<text x="230" y="96">block</text>
+</g>
+<path d="M260 92h10"></path>
+<path d="M270 92h10"></path>
+<g class="terminal ">
+<path d="M280 92h0"></path>
+<path d="M316 92h0"></path>
+<rect x="280" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="298" y="96">&#60;%</text>
+</g>
+<path d="M316 92h10"></path>
+<path d="M326 92h10"></path>
+<g class="terminal ">
+<path d="M336 92h0"></path>
+<path d="M380 92h0"></path>
+<rect x="336" y="81" width="44" height="22" rx="10" ry="10"></rect>
+<text x="358" y="96">end</text>
+</g>
+<path d="M380 92h10"></path>
+<path d="M390 92h10"></path>
+<g class="terminal ">
+<path d="M400 92h0"></path>
+<path d="M436 92h0"></path>
+<rect x="400" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="418" y="96">%></text>
+</g>
+</g>
+<path d="M576 92h10"></path>
+<path d="M586 92h0"></path>
+</g>
+<path d="M586 92h10"></path>
+<path d="M 596 92 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_print.svg
+++ b/docs/images/stmt_print.svg
@@ -1,0 +1,116 @@
+<svg class="railroad-diagram" width="504" height="62" viewBox="0 0 504 62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M454 31h0"></path>
+<g class="terminal ">
+<path d="M50 31h0"></path>
+<path d="M86 31h0"></path>
+<rect x="50" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="35">&#60;%</text>
+</g>
+<path d="M86 31h10"></path>
+<path d="M96 31h10"></path>
+<g class="terminal ">
+<path d="M106 31h0"></path>
+<path d="M166 31h0"></path>
+<rect x="106" y="20" width="60" height="22" rx="10" ry="10"></rect>
+<text x="136" y="35">print</text>
+</g>
+<path d="M166 31h10"></path>
+<path d="M176 31h10"></path>
+<g class="non-terminal ">
+<path d="M186 31h0"></path>
+<path d="M230 31h0"></path>
+<rect x="186" y="20" width="44" height="22"></rect>
+<text x="208" y="35">var</text>
+</g>
+<path d="M230 31h10"></path>
+<path d="M240 31h10"></path>
+<g class="terminal ">
+<path d="M250 31h0"></path>
+<path d="M278 31h0"></path>
+<rect x="250" y="20" width="28" height="22" rx="10" ry="10"></rect>
+<text x="264" y="35">(</text>
+</g>
+<path d="M278 31h10"></path>
+<path d="M288 31h10"></path>
+<g class="non-terminal ">
+<path d="M298 31h0"></path>
+<path d="M350 31h0"></path>
+<rect x="298" y="20" width="52" height="22"></rect>
+<text x="324" y="35">expr</text>
+</g>
+<path d="M350 31h10"></path>
+<path d="M360 31h10"></path>
+<g class="terminal ">
+<path d="M370 31h0"></path>
+<path d="M398 31h0"></path>
+<rect x="370" y="20" width="28" height="22" rx="10" ry="10"></rect>
+<text x="384" y="35">)</text>
+</g>
+<path d="M398 31h10"></path>
+<path d="M408 31h10"></path>
+<g class="terminal ">
+<path d="M418 31h0"></path>
+<path d="M454 31h0"></path>
+<rect x="418" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="436" y="35">%></text>
+</g>
+</g>
+<path d="M454 31h10"></path>
+<path d="M 464 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_print_expr.svg
+++ b/docs/images/stmt_print_expr.svg
@@ -1,0 +1,84 @@
+<svg class="railroad-diagram" width="264" height="62" viewBox="0 0 264 62" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M214 31h0"></path>
+<g class="terminal ">
+<path d="M50 31h0"></path>
+<path d="M86 31h0"></path>
+<rect x="50" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="35">&#60;%</text>
+</g>
+<path d="M86 31h10"></path>
+<path d="M96 31h10"></path>
+<g class="non-terminal ">
+<path d="M106 31h0"></path>
+<path d="M158 31h0"></path>
+<rect x="106" y="20" width="52" height="22"></rect>
+<text x="132" y="35">expr</text>
+</g>
+<path d="M158 31h10"></path>
+<path d="M168 31h10"></path>
+<g class="terminal ">
+<path d="M178 31h0"></path>
+<path d="M214 31h0"></path>
+<rect x="178" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="196" y="35">%></text>
+</g>
+</g>
+<path d="M214 31h10"></path>
+<path d="M 224 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_require.svg
+++ b/docs/images/stmt_require.svg
@@ -1,0 +1,164 @@
+<svg class="railroad-diagram" width="776" height="88" viewBox="0 0 776 88" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 34v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 44h10"></path>
+<g>
+<path d="M50 44h0"></path>
+<path d="M726 44h0"></path>
+<g class="terminal ">
+<path d="M50 44h0"></path>
+<path d="M86 44h0"></path>
+<rect x="50" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="68" y="48">&#60;%</text>
+</g>
+<path d="M86 44h10"></path>
+<path d="M96 44h10"></path>
+<g class="terminal ">
+<path d="M106 44h0"></path>
+<path d="M182 44h0"></path>
+<rect x="106" y="33" width="76" height="22" rx="10" ry="10"></rect>
+<text x="144" y="48">require</text>
+</g>
+<path d="M182 44h10"></path>
+<path d="M192 44h10"></path>
+<g class="non-terminal ">
+<path d="M202 44h0"></path>
+<path d="M254 44h0"></path>
+<rect x="202" y="33" width="52" height="22"></rect>
+<text x="228" y="48">expr</text>
+</g>
+<path d="M254 44h10"></path>
+<g>
+<path d="M264 44h0"></path>
+<path d="M424 44h0"></path>
+<path d="M264 44a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M284 20h120"></path>
+</g>
+<path d="M404 20a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M264 44h20"></path>
+<g>
+<path d="M284 44h0"></path>
+<path d="M404 44h0"></path>
+<path d="M284 44h10"></path>
+<g>
+<path d="M294 44h0"></path>
+<path d="M394 44h0"></path>
+<g class="terminal ">
+<path d="M294 44h0"></path>
+<path d="M322 44h0"></path>
+<rect x="294" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="308" y="48">,</text>
+</g>
+<path d="M322 44h10"></path>
+<path d="M332 44h10"></path>
+<g class="non-terminal ">
+<path d="M342 44h0"></path>
+<path d="M394 44h0"></path>
+<rect x="342" y="33" width="52" height="22"></rect>
+<text x="368" y="48">expr</text>
+</g>
+</g>
+<path d="M394 44h10"></path>
+<path d="M294 44a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M294 68h100"></path>
+</g>
+<path d="M394 68a10 10 0 0 0 10 -10v-4a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M404 44h20"></path>
+</g>
+<path d="M424 44h10"></path>
+<g class="terminal ">
+<path d="M434 44h0"></path>
+<path d="M470 44h0"></path>
+<rect x="434" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="452" y="48">%></text>
+</g>
+<path d="M470 44h10"></path>
+<path d="M480 44h10"></path>
+<g class="non-terminal ">
+<path d="M490 44h0"></path>
+<path d="M550 44h0"></path>
+<rect x="490" y="33" width="60" height="22"></rect>
+<text x="520" y="48">block</text>
+</g>
+<path d="M550 44h10"></path>
+<path d="M560 44h10"></path>
+<g class="terminal ">
+<path d="M570 44h0"></path>
+<path d="M606 44h0"></path>
+<rect x="570" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="588" y="48">&#60;%</text>
+</g>
+<path d="M606 44h10"></path>
+<path d="M616 44h10"></path>
+<g class="terminal ">
+<path d="M626 44h0"></path>
+<path d="M670 44h0"></path>
+<rect x="626" y="33" width="44" height="22" rx="10" ry="10"></rect>
+<text x="648" y="48">end</text>
+</g>
+<path d="M670 44h10"></path>
+<path d="M680 44h10"></path>
+<g class="terminal ">
+<path d="M690 44h0"></path>
+<path d="M726 44h0"></path>
+<rect x="690" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="708" y="48">%></text>
+</g>
+</g>
+<path d="M726 44h10"></path>
+<path d="M 736 44 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_template.svg
+++ b/docs/images/stmt_template.svg
@@ -1,0 +1,149 @@
+<svg class="railroad-diagram" width="504" height="110" viewBox="0 0 504 110" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h10"></path>
+<path d="M434 31h10"></path>
+<g class="terminal ">
+<path d="M70 31h0"></path>
+<path d="M106 31h0"></path>
+<rect x="70" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="88" y="35">&#60;%</text>
+</g>
+<path d="M106 31h10"></path>
+<path d="M116 31h10"></path>
+<g class="terminal ">
+<path d="M126 31h0"></path>
+<path d="M210 31h0"></path>
+<rect x="126" y="20" width="84" height="22" rx="10" ry="10"></rect>
+<text x="168" y="35">template</text>
+</g>
+<path d="M210 31h10"></path>
+<path d="M220 31h10"></path>
+<g class="terminal ">
+<path d="M230 31h0"></path>
+<path d="M258 31h0"></path>
+<rect x="230" y="20" width="28" height="22" rx="10" ry="10"></rect>
+<text x="244" y="35">(</text>
+</g>
+<path d="M258 31h10"></path>
+<path d="M268 31h10"></path>
+<g class="non-terminal ">
+<path d="M278 31h0"></path>
+<path d="M330 31h0"></path>
+<rect x="278" y="20" width="52" height="22"></rect>
+<text x="304" y="35">expr</text>
+</g>
+<path d="M330 31h10"></path>
+<path d="M340 31h10"></path>
+<g class="terminal ">
+<path d="M350 31h0"></path>
+<path d="M378 31h0"></path>
+<rect x="350" y="20" width="28" height="22" rx="10" ry="10"></rect>
+<text x="364" y="35">)</text>
+</g>
+<path d="M378 31h10"></path>
+<path d="M388 31h10"></path>
+<g class="terminal ">
+<path d="M398 31h0"></path>
+<path d="M434 31h0"></path>
+<rect x="398" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="416" y="35">%></text>
+</g>
+</g>
+<path d="M444 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-384a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 79h74"></path>
+<path d="M370 79h74"></path>
+<g class="non-terminal ">
+<path d="M134 79h0"></path>
+<path d="M194 79h0"></path>
+<rect x="134" y="68" width="60" height="22"></rect>
+<text x="164" y="83">block</text>
+</g>
+<path d="M194 79h10"></path>
+<path d="M204 79h10"></path>
+<g class="terminal ">
+<path d="M214 79h0"></path>
+<path d="M250 79h0"></path>
+<rect x="214" y="68" width="36" height="22" rx="10" ry="10"></rect>
+<text x="232" y="83">&#60;%</text>
+</g>
+<path d="M250 79h10"></path>
+<path d="M260 79h10"></path>
+<g class="terminal ">
+<path d="M270 79h0"></path>
+<path d="M314 79h0"></path>
+<rect x="270" y="68" width="44" height="22" rx="10" ry="10"></rect>
+<text x="292" y="83">end</text>
+</g>
+<path d="M314 79h10"></path>
+<path d="M324 79h10"></path>
+<g class="terminal ">
+<path d="M334 79h0"></path>
+<path d="M370 79h0"></path>
+<rect x="334" y="68" width="36" height="22" rx="10" ry="10"></rect>
+<text x="352" y="83">%></text>
+</g>
+</g>
+<path d="M444 79h10"></path>
+<path d="M454 79h0"></path>
+</g>
+<path d="M454 79h10"></path>
+<path d="M 464 79 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_while.svg
+++ b/docs/images/stmt_while.svg
@@ -1,0 +1,234 @@
+<svg class="railroad-diagram" width="398" height="363" viewBox="0 0 398 363" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h10"></path>
+<path d="M70 31h10"></path>
+<g>
+<path d="M80 31h25"></path>
+<path d="M293 31h25"></path>
+<g class="terminal ">
+<path d="M105 31h0"></path>
+<path d="M141 31h0"></path>
+<rect x="105" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="123" y="35">&#60;%</text>
+</g>
+<path d="M141 31h10"></path>
+<path d="M151 31h10"></path>
+<g class="terminal ">
+<path d="M161 31h0"></path>
+<path d="M221 31h0"></path>
+<rect x="161" y="20" width="60" height="22" rx="10" ry="10"></rect>
+<text x="191" y="35">while</text>
+</g>
+<path d="M221 31h10"></path>
+<path d="M231 31h10"></path>
+<g class="non-terminal ">
+<path d="M241 31h0"></path>
+<path d="M293 31h0"></path>
+<rect x="241" y="20" width="52" height="22"></rect>
+<text x="267" y="35">expr</text>
+</g>
+</g>
+<path d="M318 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-238a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 92h29"></path>
+<path d="M289 92h29"></path>
+<path d="M109 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M129 68h140"></path>
+</g>
+<path d="M269 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M109 92h20"></path>
+<g>
+<path d="M129 92h0"></path>
+<path d="M269 92h0"></path>
+<g class="terminal ">
+<path d="M129 92h0"></path>
+<path d="M197 92h0"></path>
+<rect x="129" y="81" width="68" height="22" rx="10" ry="10"></rect>
+<text x="163" y="96">offset</text>
+</g>
+<path d="M197 92h10"></path>
+<path d="M207 92h10"></path>
+<g class="non-terminal ">
+<path d="M217 92h0"></path>
+<path d="M269 92h0"></path>
+<rect x="217" y="81" width="52" height="22"></rect>
+<text x="243" y="96">expr</text>
+</g>
+</g>
+<path d="M269 92h20"></path>
+</g>
+<path d="M318 92a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-238a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M80 153h10"></path>
+<path d="M308 153h10"></path>
+<g>
+<path d="M90 153h0"></path>
+<path d="M262 153h0"></path>
+<path d="M90 153a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M110 129h132"></path>
+</g>
+<path d="M242 129a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M90 153h20"></path>
+<g>
+<path d="M110 153h0"></path>
+<path d="M242 153h0"></path>
+<g class="terminal ">
+<path d="M110 153h0"></path>
+<path d="M170 153h0"></path>
+<rect x="110" y="142" width="60" height="22" rx="10" ry="10"></rect>
+<text x="140" y="157">limit</text>
+</g>
+<path d="M170 153h10"></path>
+<path d="M180 153h10"></path>
+<g class="non-terminal ">
+<path d="M190 153h0"></path>
+<path d="M242 153h0"></path>
+<rect x="190" y="142" width="52" height="22"></rect>
+<text x="216" y="157">expr</text>
+</g>
+</g>
+<path d="M242 153h20"></path>
+</g>
+<path d="M262 153h10"></path>
+<g class="terminal ">
+<path d="M272 153h0"></path>
+<path d="M308 153h0"></path>
+<rect x="272" y="142" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="157">%></text>
+</g>
+</g>
+<path d="M318 153h10"></path>
+<path d="M328 153h10"></path>
+</g>
+<path d="M338 153a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-278a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 201h43"></path>
+<path d="M295 201h43"></path>
+<path d="M103 201h10"></path>
+<g>
+<path d="M113 201h0"></path>
+<path d="M285 201h0"></path>
+<path d="M113 201h20"></path>
+<g class="non-terminal ">
+<path d="M133 201h36"></path>
+<path d="M229 201h36"></path>
+<rect x="169" y="190" width="60" height="22"></rect>
+<text x="199" y="205">block</text>
+</g>
+<path d="M265 201h20"></path>
+<path d="M113 201a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M133 236h0"></path>
+<path d="M265 236h0"></path>
+<rect x="133" y="225" width="132" height="22" rx="10" ry="10"></rect>
+<text x="199" y="240">&#60;% continue %></text>
+</g>
+<path d="M265 236a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M113 201a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g class="terminal ">
+<path d="M133 271h12"></path>
+<path d="M253 271h12"></path>
+<rect x="145" y="260" width="108" height="22" rx="10" ry="10"></rect>
+<text x="199" y="275">&#60;% break %></text>
+</g>
+<path d="M265 271a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M285 201h10"></path>
+<path d="M113 201a10 10 0 0 0 -10 10v74a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M113 295h172"></path>
+</g>
+<path d="M285 295a10 10 0 0 0 10 -10v-74a10 10 0 0 0 -10 -10"></path>
+</g>
+<path d="M338 201a10 10 0 0 1 10 10v87a10 10 0 0 1 -10 10h-278a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 332h61"></path>
+<path d="M277 332h61"></path>
+<g class="terminal ">
+<path d="M121 332h0"></path>
+<path d="M157 332h0"></path>
+<rect x="121" y="321" width="36" height="22" rx="10" ry="10"></rect>
+<text x="139" y="336">&#60;%</text>
+</g>
+<path d="M157 332h10"></path>
+<path d="M167 332h10"></path>
+<g class="terminal ">
+<path d="M177 332h0"></path>
+<path d="M221 332h0"></path>
+<rect x="177" y="321" width="44" height="22" rx="10" ry="10"></rect>
+<text x="199" y="336">end</text>
+</g>
+<path d="M221 332h10"></path>
+<path d="M231 332h10"></path>
+<g class="terminal ">
+<path d="M241 332h0"></path>
+<path d="M277 332h0"></path>
+<rect x="241" y="321" width="36" height="22" rx="10" ry="10"></rect>
+<text x="259" y="336">%></text>
+</g>
+</g>
+<path d="M338 332h10"></path>
+<path d="M348 332h0"></path>
+</g>
+<path d="M348 332h10"></path>
+<path d="M 358 332 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_while_event.svg
+++ b/docs/images/stmt_while_event.svg
@@ -1,0 +1,293 @@
+<svg class="railroad-diagram" width="508" height="276" viewBox="0 0 508 276" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 31h10"></path>
+<g>
+<path d="M50 31h0"></path>
+<path d="M50 31h10"></path>
+<g>
+<path d="M60 31h32"></path>
+<path d="M416 31h32"></path>
+<g class="terminal ">
+<path d="M92 31h0"></path>
+<path d="M128 31h0"></path>
+<rect x="92" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="110" y="35">&#60;%</text>
+</g>
+<path d="M128 31h10"></path>
+<path d="M138 31h10"></path>
+<g class="terminal ">
+<path d="M148 31h0"></path>
+<path d="M208 31h0"></path>
+<rect x="148" y="20" width="60" height="22" rx="10" ry="10"></rect>
+<text x="178" y="35">while</text>
+</g>
+<path d="M208 31h10"></path>
+<path d="M218 31h10"></path>
+<g class="non-terminal ">
+<path d="M228 31h0"></path>
+<path d="M280 31h0"></path>
+<rect x="228" y="20" width="52" height="22"></rect>
+<text x="254" y="35">expr</text>
+</g>
+<path d="M280 31h10"></path>
+<path d="M290 31h10"></path>
+<g class="terminal ">
+<path d="M300 31h0"></path>
+<path d="M336 31h0"></path>
+<rect x="300" y="20" width="36" height="22" rx="10" ry="10"></rect>
+<text x="318" y="35">%></text>
+</g>
+<path d="M336 31h10"></path>
+<path d="M346 31h10"></path>
+<g class="non-terminal ">
+<path d="M356 31h0"></path>
+<path d="M416 31h0"></path>
+<rect x="356" y="20" width="60" height="22"></rect>
+<text x="386" y="35">block</text>
+</g>
+</g>
+<path d="M448 31a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v17a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 92h0"></path>
+<path d="M448 92h0"></path>
+<path d="M60 92a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M80 68h348"></path>
+</g>
+<path d="M428 68a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M60 92h20"></path>
+<g>
+<path d="M80 92h0"></path>
+<path d="M428 92h0"></path>
+<path d="M80 92h20"></path>
+<g>
+<path d="M100 92h20"></path>
+<path d="M388 92h20"></path>
+<g class="terminal ">
+<path d="M120 92h0"></path>
+<path d="M156 92h0"></path>
+<rect x="120" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="96">&#60;%</text>
+</g>
+<path d="M156 92h10"></path>
+<path d="M166 92h10"></path>
+<g class="terminal ">
+<path d="M176 92h0"></path>
+<path d="M252 92h0"></path>
+<rect x="176" y="81" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="96">onbegin</text>
+</g>
+<path d="M252 92h10"></path>
+<path d="M262 92h10"></path>
+<g class="terminal ">
+<path d="M272 92h0"></path>
+<path d="M308 92h0"></path>
+<rect x="272" y="81" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="96">%></text>
+</g>
+<path d="M308 92h10"></path>
+<path d="M318 92h10"></path>
+<g class="non-terminal ">
+<path d="M328 92h0"></path>
+<path d="M388 92h0"></path>
+<rect x="328" y="81" width="60" height="22"></rect>
+<text x="358" y="96">block</text>
+</g>
+</g>
+<path d="M408 92h20"></path>
+<path d="M80 92a10 10 0 0 1 10 10v15a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 127h28"></path>
+<path d="M380 127h28"></path>
+<g class="terminal ">
+<path d="M128 127h0"></path>
+<path d="M164 127h0"></path>
+<rect x="128" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="146" y="131">&#60;%</text>
+</g>
+<path d="M164 127h10"></path>
+<path d="M174 127h10"></path>
+<g class="terminal ">
+<path d="M184 127h0"></path>
+<path d="M244 127h0"></path>
+<rect x="184" y="116" width="60" height="22" rx="10" ry="10"></rect>
+<text x="214" y="131">onend</text>
+</g>
+<path d="M244 127h10"></path>
+<path d="M254 127h10"></path>
+<g class="terminal ">
+<path d="M264 127h0"></path>
+<path d="M300 127h0"></path>
+<rect x="264" y="116" width="36" height="22" rx="10" ry="10"></rect>
+<text x="282" y="131">%></text>
+</g>
+<path d="M300 127h10"></path>
+<path d="M310 127h10"></path>
+<g class="non-terminal ">
+<path d="M320 127h0"></path>
+<path d="M380 127h0"></path>
+<rect x="320" y="116" width="60" height="22"></rect>
+<text x="350" y="131">block</text>
+</g>
+</g>
+<path d="M408 127a10 10 0 0 0 10 -10v-15a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v50a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 162h0"></path>
+<path d="M408 162h0"></path>
+<g class="terminal ">
+<path d="M100 162h0"></path>
+<path d="M136 162h0"></path>
+<rect x="100" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="118" y="166">&#60;%</text>
+</g>
+<path d="M136 162h10"></path>
+<path d="M146 162h10"></path>
+<g class="terminal ">
+<path d="M156 162h0"></path>
+<path d="M272 162h0"></path>
+<rect x="156" y="151" width="116" height="22" rx="10" ry="10"></rect>
+<text x="214" y="166">betweenitems</text>
+</g>
+<path d="M272 162h10"></path>
+<path d="M282 162h10"></path>
+<g class="terminal ">
+<path d="M292 162h0"></path>
+<path d="M328 162h0"></path>
+<rect x="292" y="151" width="36" height="22" rx="10" ry="10"></rect>
+<text x="310" y="166">%></text>
+</g>
+<path d="M328 162h10"></path>
+<path d="M338 162h10"></path>
+<g class="non-terminal ">
+<path d="M348 162h0"></path>
+<path d="M408 162h0"></path>
+<rect x="348" y="151" width="60" height="22"></rect>
+<text x="378" y="166">block</text>
+</g>
+</g>
+<path d="M408 162a10 10 0 0 0 10 -10v-50a10 10 0 0 1 10 -10"></path>
+<path d="M80 92a10 10 0 0 1 10 10v85a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M100 197h20"></path>
+<path d="M388 197h20"></path>
+<g class="terminal ">
+<path d="M120 197h0"></path>
+<path d="M156 197h0"></path>
+<rect x="120" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="138" y="201">&#60;%</text>
+</g>
+<path d="M156 197h10"></path>
+<path d="M166 197h10"></path>
+<g class="terminal ">
+<path d="M176 197h0"></path>
+<path d="M252 197h0"></path>
+<rect x="176" y="186" width="76" height="22" rx="10" ry="10"></rect>
+<text x="214" y="201">onempty</text>
+</g>
+<path d="M252 197h10"></path>
+<path d="M262 197h10"></path>
+<g class="terminal ">
+<path d="M272 197h0"></path>
+<path d="M308 197h0"></path>
+<rect x="272" y="186" width="36" height="22" rx="10" ry="10"></rect>
+<text x="290" y="201">%></text>
+</g>
+<path d="M308 197h10"></path>
+<path d="M318 197h10"></path>
+<g class="non-terminal ">
+<path d="M328 197h0"></path>
+<path d="M388 197h0"></path>
+<rect x="328" y="186" width="60" height="22"></rect>
+<text x="358" y="201">block</text>
+</g>
+</g>
+<path d="M408 197a10 10 0 0 0 10 -10v-85a10 10 0 0 1 10 -10"></path>
+</g>
+<path d="M428 92h20"></path>
+</g>
+<path d="M448 92a10 10 0 0 1 10 10v109a10 10 0 0 1 -10 10h-388a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 245h116"></path>
+<path d="M332 245h116"></path>
+<g class="terminal ">
+<path d="M176 245h0"></path>
+<path d="M212 245h0"></path>
+<rect x="176" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="194" y="249">&#60;%</text>
+</g>
+<path d="M212 245h10"></path>
+<path d="M222 245h10"></path>
+<g class="terminal ">
+<path d="M232 245h0"></path>
+<path d="M276 245h0"></path>
+<rect x="232" y="234" width="44" height="22" rx="10" ry="10"></rect>
+<text x="254" y="249">end</text>
+</g>
+<path d="M276 245h10"></path>
+<path d="M286 245h10"></path>
+<g class="terminal ">
+<path d="M296 245h0"></path>
+<path d="M332 245h0"></path>
+<rect x="296" y="234" width="36" height="22" rx="10" ry="10"></rect>
+<text x="314" y="249">%></text>
+</g>
+</g>
+<path d="M448 245h10"></path>
+<path d="M458 245h0"></path>
+</g>
+<path d="M458 245h10"></path>
+<path d="M 468 245 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/images/stmt_with.svg
+++ b/docs/images/stmt_with.svg
@@ -1,0 +1,177 @@
+<svg class="railroad-diagram" width="636" height="171" viewBox="0 0 636 171" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g transform="translate(.5 .5)">
+<g>
+<path d="M20 34v20m10 -20v20m-10 -10h20"></path>
+</g>
+<path d="M40 44h10"></path>
+<g>
+<path d="M50 44h0"></path>
+<path d="M50 44h10"></path>
+<g>
+<path d="M60 44h10"></path>
+<path d="M566 44h10"></path>
+<g class="terminal ">
+<path d="M70 44h0"></path>
+<path d="M106 44h0"></path>
+<rect x="70" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="88" y="48">&#60;%</text>
+</g>
+<path d="M106 44h10"></path>
+<path d="M116 44h10"></path>
+<g class="terminal ">
+<path d="M126 44h0"></path>
+<path d="M202 44h0"></path>
+<rect x="126" y="33" width="76" height="22" rx="10" ry="10"></rect>
+<text x="164" y="48">extends</text>
+</g>
+<path d="M202 44h10"></path>
+<path d="M212 44h10"></path>
+<g class="terminal ">
+<path d="M222 44h0"></path>
+<path d="M250 44h0"></path>
+<rect x="222" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="236" y="48">(</text>
+</g>
+<path d="M250 44h10"></path>
+<path d="M260 44h10"></path>
+<g class="non-terminal ">
+<path d="M270 44h0"></path>
+<path d="M322 44h0"></path>
+<rect x="270" y="33" width="52" height="22"></rect>
+<text x="296" y="48">expr</text>
+</g>
+<path d="M322 44h10"></path>
+<g>
+<path d="M332 44h0"></path>
+<path d="M472 44h0"></path>
+<path d="M332 44a10 10 0 0 0 10 -10v-4a10 10 0 0 1 10 -10"></path>
+<g>
+<path d="M352 20h100"></path>
+</g>
+<path d="M452 20a10 10 0 0 1 10 10v4a10 10 0 0 0 10 10"></path>
+<path d="M332 44h20"></path>
+<g>
+<path d="M352 44h0"></path>
+<path d="M452 44h0"></path>
+<g class="terminal ">
+<path d="M352 44h0"></path>
+<path d="M380 44h0"></path>
+<rect x="352" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="366" y="48">,</text>
+</g>
+<path d="M380 44h10"></path>
+<path d="M390 44h10"></path>
+<g class="non-terminal ">
+<path d="M400 44h0"></path>
+<path d="M452 44h0"></path>
+<rect x="400" y="33" width="52" height="22"></rect>
+<text x="426" y="48">expr</text>
+</g>
+</g>
+<path d="M452 44h20"></path>
+</g>
+<path d="M472 44h10"></path>
+<g class="terminal ">
+<path d="M482 44h0"></path>
+<path d="M510 44h0"></path>
+<rect x="482" y="33" width="28" height="22" rx="10" ry="10"></rect>
+<text x="496" y="48">)</text>
+</g>
+<path d="M510 44h10"></path>
+<path d="M520 44h10"></path>
+<g class="terminal ">
+<path d="M530 44h0"></path>
+<path d="M566 44h0"></path>
+<rect x="530" y="33" width="36" height="22" rx="10" ry="10"></rect>
+<text x="548" y="48">%></text>
+</g>
+</g>
+<path d="M576 44a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-516a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g class="non-terminal ">
+<path d="M60 92h228"></path>
+<path d="M348 92h228"></path>
+<rect x="288" y="81" width="60" height="22"></rect>
+<text x="318" y="96">block</text>
+</g>
+<path d="M576 92a10 10 0 0 1 10 10v4a10 10 0 0 1 -10 10h-516a10 10 0 0 0 -10 10v4a10 10 0 0 0 10 10"></path>
+<g>
+<path d="M60 140h180"></path>
+<path d="M396 140h180"></path>
+<g class="terminal ">
+<path d="M240 140h0"></path>
+<path d="M276 140h0"></path>
+<rect x="240" y="129" width="36" height="22" rx="10" ry="10"></rect>
+<text x="258" y="144">&#60;%</text>
+</g>
+<path d="M276 140h10"></path>
+<path d="M286 140h10"></path>
+<g class="terminal ">
+<path d="M296 140h0"></path>
+<path d="M340 140h0"></path>
+<rect x="296" y="129" width="44" height="22" rx="10" ry="10"></rect>
+<text x="318" y="144">end</text>
+</g>
+<path d="M340 140h10"></path>
+<path d="M350 140h10"></path>
+<g class="terminal ">
+<path d="M360 140h0"></path>
+<path d="M396 140h0"></path>
+<rect x="360" y="129" width="36" height="22" rx="10" ry="10"></rect>
+<text x="378" y="144">%></text>
+</g>
+</g>
+<path d="M576 140h10"></path>
+<path d="M586 140h0"></path>
+</g>
+<path d="M586 140h10"></path>
+<path d="M 596 140 h 20 m -10 -10 v 20 m 10 -20 v 20"></path>
+</g>
+<style>
+	svg {
+		background-color: hsl(30,20%,95%);
+	}
+	path {
+		stroke-width: 3;
+		stroke: black;
+		fill: rgba(0,0,0,0);
+	}
+	text {
+		font: bold 14px monospace;
+		text-anchor: middle;
+		white-space: pre;
+	}
+	text.diagram-text {
+		font-size: 12px;
+	}
+	text.diagram-arrow {
+		font-size: 16px;
+	}
+	text.label {
+		text-anchor: start;
+	}
+	text.comment {
+		font: italic 12px monospace;
+	}
+	g.non-terminal text {
+		/&#42;font-style: italic;&#42;/
+	}
+	rect {
+		stroke-width: 3;
+		stroke: black;
+		fill: hsl(120,100%,90%);
+	}
+	rect.group-box {
+		stroke: gray;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+	path.diagram-text {
+		stroke-width: 3;
+		stroke: black;
+		fill: white;
+		cursor: help;
+	}
+	g.diagram-text:hover path.diagram-text {
+		fill: #eee;
+	}</style>
+</svg>

--- a/docs/rail-road-diagrams.txt
+++ b/docs/rail-road-diagrams.txt
@@ -1,0 +1,330 @@
+https://tabatkins.github.io/railroad-diagrams/generator.html
+https://github.com/tabatkins/railroad-diagrams/blob/gh-pages/README-js.md
+
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('%3A%3D')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20)%0A)
+
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       NonTerminal('var'),
+       Terminal(':='),
+       NonTerminal('expr'),        
+       Terminal('%>'),
+   )
+)
+
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('for')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('%3A%3D')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20Terminal('to')%2C%0A%20%20%20%20%20%20%20%20%20Terminal('downto'))%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('step')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('for'),
+       NonTerminal('var'),
+       Terminal(':='),
+       NonTerminal('expr'),
+       Choice(0,
+         Terminal('to'),
+         Terminal('downto')),
+       NonTerminal('expr'),
+       Optional(
+         Sequence(Terminal('step'),  NonTerminal('expr'))
+       ),
+       Optional(
+         Sequence(Terminal('offset'),  NonTerminal('expr'))
+       ),
+       Optional(
+         Sequence(Terminal('limit'),  NonTerminal('expr'))
+       ), 
+       Terminal('%>'),
+       OneOrMore(
+         Choice(0,
+           NonTerminal('block'),
+           Terminal('<% continue %>'),
+           Terminal('<% break %>'),
+         )
+       ),
+       Terminal('<% end %>'),
+  )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0A%20Sequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('for')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('in')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
+
+Diagram(
+ Sequence(
+       Terminal('<%'),
+       Terminal('for'),
+       NonTerminal('var'),
+       Terminal('in'),
+       NonTerminal('expr'),
+       Optional(
+         Sequence(Terminal('offset'),  NonTerminal('expr'))
+       ),
+       Optional(
+         Sequence(Terminal('limit'),  NonTerminal('expr'))
+       ), 
+       Terminal('%>'),
+       OneOrMore(
+         Choice(0,
+           NonTerminal('block'),
+           Terminal('<% continue %>'),
+           Terminal('<% break %>'),
+         )
+       ),
+       Terminal('<% end %>'),
+  )
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('while')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('while'),
+       NonTerminal('expr'),
+       Optional(
+         Sequence(Terminal('offset'),  NonTerminal('expr'))
+       ),
+       Optional(
+         Sequence(Terminal('limit'),  NonTerminal('expr'))
+       ), 
+       Terminal('%>'),
+       OneOrMore(
+         Choice(0,
+           NonTerminal('block'),
+           Terminal('<% continue %>'),
+           Terminal('<% break %>'),
+         )
+       ),
+       Terminal('<% end %>'),
+  )
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('if')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20elif%20')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20else%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('if'),
+       NonTerminal('expr'),
+       Terminal('%>'),
+       NonTerminal('block'),
+       ZeroOrMore(
+         Sequence(
+           Terminal('<% elif '),
+           NonTerminal('expr'),
+           Terminal('%>'),
+           NonTerminal('block'),
+         ),
+       ),
+       Optional(
+         Sequence(
+           Terminal('<% else %>'),
+           NonTerminal('block'),
+         ),
+       ),
+       Terminal('<% end %>'),
+  )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('include')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20)%0A)
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('include'),
+       Terminal('('),
+       NonTerminal('expr'),  
+       Optional(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),      
+       Terminal(')'),
+       Terminal('%>'),
+   )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('extends')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('extends'),
+       Terminal('('),
+       NonTerminal('expr'),  
+       Optional(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal(')'),
+       Terminal('%>'),
+       NonTerminal('block'),
+       Terminal('<% end %>'), 
+   )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('with')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('with'),
+       NonTerminal('expr'),  
+       ZeroOrMore(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal('%>'),
+       NonTerminal('block'),
+       Terminal('<% end %>'), 
+   )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('template')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('template'),
+       NonTerminal('expr'),  
+       Optional(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal('%>'),
+       NonTerminal('block'),
+       Terminal('<% end %>'), 
+   )
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('require')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('require'),
+       NonTerminal('expr'),  
+       ZeroOrMore(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal('%>'),
+       NonTerminal('block'),
+       Terminal('<% end %>'), 
+   )
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25%20ignorenl%20%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<% ignorenl %>'),
+       NonTerminal('block'),
+       Terminal('<% end %>'), 
+   )
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('cycle')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20)%0A)
+
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('cycle'),
+       Terminal('('),
+       NonTerminal('expr'),  
+       ZeroOrMore(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal(')'),
+       Terminal('%>'),
+   )
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ATerminal('_')%2C%0A)
+
+Diagram(
+Terminal('_'),
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%5C'')%2C%0A%20%20%20%20%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%5Ba..zA..Z0..9...%5D')%2C%0A%20%20%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%5C'')%0A%20%20%20%20%20)%2C%0A)
+
+Diagram(Sequence(
+           Terminal('\''),
+           ZeroOrMore(
+             Terminal('[a..zA..Z0..9...]'),
+           ),
+           Terminal('\'')
+     ),
+)
+-------------------------
+
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%22')%2C%0A%20%20%20%20%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%5Ba..zA..Z0..9...%5D')%0A%20%20%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%22')%0A%20%20%20%20%20)%2C%0A)
+
+Diagram(Sequence(
+           Terminal('"'),
+           ZeroOrMore(
+             Terminal('[a..zA..Z0..9...]')
+           ),
+           Terminal('"')
+     ),
+)
+-------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20%20OneOrMore('%5B0..9%5D')%2C%0A%20%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20Terminal('.')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20OneOrMore('%5B0..9%5D')%2C%0A%20%20%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Choice(0%2C%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20'e'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20'E'%0A%20%20%20%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20Choice(0%2C%20%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'%2B'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20'-'%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20OneOrMore('%5B0..9%5D')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20)%0A)
+Diagram(
+Sequence(
+        OneOrMore('[0..9]'),
+        Optional(
+           Sequence(
+              Terminal('.'),
+             OneOrMore('[0..9]'),
+           ),
+        ),
+        Optional(
+          Sequence(
+            Choice(0, 
+              'e',
+              'E'
+            ),
+            Optional(
+              Choice(0, 
+                '+',
+                '-'
+              )
+            ),
+            OneOrMore('[0..9]'),
+          )
+        )
+     )
+)
+-------------------------
+Diagram(
+)
+-------------------------
+Diagram(
+)
+-------------------------
+Diagram(
+)
+-------------------------

--- a/docs/rail-road-diagrams.txt
+++ b/docs/rail-road-diagrams.txt
@@ -21,116 +21,250 @@ Sequence(
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('for')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('%3A%3D')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20Terminal('to')%2C%0A%20%20%20%20%20%20%20%20%20Terminal('downto'))%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('step')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
 
 Diagram(
-Sequence(
+ Stack(
+    Stack(
+       Sequence(
        Terminal('<%'),
        Terminal('for'),
        NonTerminal('var'),
        Terminal(':='),
        NonTerminal('expr'),
-       Choice(0,
-         Terminal('to'),
-         Terminal('downto')),
+       Terminal('to'),
        NonTerminal('expr'),
+     ),
        Optional(
          Sequence(Terminal('step'),  NonTerminal('expr'))
        ),
        Optional(
          Sequence(Terminal('offset'),  NonTerminal('expr'))
        ),
+       Sequence(
        Optional(
          Sequence(Terminal('limit'),  NonTerminal('expr'))
        ), 
-       Terminal('%>'),
-       OneOrMore(
+       Terminal('%>'), ),
+  ), 
+        OneOrMore(
          Choice(0,
            NonTerminal('block'),
            Terminal('<% continue %>'),
            Terminal('<% break %>'),
          )
        ),
-       Terminal('<% end %>'),
-  )
+Sequence(Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+    )
 )
 -------------------------
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0A%20Sequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('for')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('in')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
 
 Diagram(
- Sequence(
+ Stack(
+    Stack(
+       Sequence(
        Terminal('<%'),
        Terminal('for'),
        NonTerminal('var'),
        Terminal('in'),
        NonTerminal('expr'),
+     ),
        Optional(
          Sequence(Terminal('offset'),  NonTerminal('expr'))
        ),
+       Sequence(
        Optional(
          Sequence(Terminal('limit'),  NonTerminal('expr'))
        ), 
-       Terminal('%>'),
-       OneOrMore(
+       Terminal('%>'), ),
+  ), 
+        OneOrMore(
          Choice(0,
            NonTerminal('block'),
            Terminal('<% continue %>'),
            Terminal('<% break %>'),
          )
        ),
-       Terminal('<% end %>'),
-  )
+Sequence(Terminal('<%'),Terminal('end'),Terminal('%>'),
 )
+    )
+)
+
+---------------------
+
+
+Diagram(
+ Stack(
+     
+      Sequence(
+       Terminal('<%'),
+       Terminal('for'),
+       NonTerminal('var'),
+       Terminal('in'),
+       NonTerminal('expr'),
+     ),
+      Optional(
+      Choice(0,
+         
+       Sequence(
+       Terminal('<%'),
+       Terminal('onbegin'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ) ,
+         
+       Sequence(
+       Terminal('<%'),
+       Terminal('onend'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+ Sequence(
+       Terminal('<%'),
+       Terminal('betweenitems'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+
+      Sequence(
+       Terminal('<%'),
+       Terminal('onempty'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+     ),),
+
+           
+
+
+Sequence(Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+    )
+)
+
 -------------------------
 
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('while')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('offset')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(Terminal('limit')%2C%20%20NonTerminal('expr'))%0A%20%20%20%20%20%20%20)%2C%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20OneOrMore(%0A%20%20%20%20%20%20%20%20%20Choice(0%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20continue%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20break%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
 
 Diagram(
-Sequence(
+ Stack(
+    Stack(
+       Sequence(
        Terminal('<%'),
        Terminal('while'),
        NonTerminal('expr'),
+     ),
        Optional(
          Sequence(Terminal('offset'),  NonTerminal('expr'))
        ),
+       Sequence(
        Optional(
          Sequence(Terminal('limit'),  NonTerminal('expr'))
        ), 
-       Terminal('%>'),
-       OneOrMore(
+       Terminal('%>'), ),
+  ), 
+        OneOrMore(
          Choice(0,
            NonTerminal('block'),
            Terminal('<% continue %>'),
            Terminal('<% break %>'),
          )
        ),
-       Terminal('<% end %>'),
-  )
+Sequence(Terminal('<%'),Terminal('end'),Terminal('%>'),
 )
+    )
+)
+
+----------------------
+
+Diagram(
+ Stack(
+     
+       Sequence(
+       Terminal('<%'),
+       Terminal('while'),
+       NonTerminal('expr'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+     ),
+
+      Optional(
+      Choice(0,
+         
+       Sequence(
+       Terminal('<%'),
+       Terminal('onbegin'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ) ,
+         
+       Sequence(
+       Terminal('<%'),
+       Terminal('onend'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+ Sequence(
+       Terminal('<%'),
+       Terminal('betweenitems'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+
+      Sequence(
+       Terminal('<%'),
+       Terminal('onempty'),
+       Terminal('%>'), 
+       NonTerminal('block'),
+          ),
+
+     ),),
+
+           
+
+
+Sequence(Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+    )
+)
+
+
+
 -------------------------
 
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('if')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20elif%20')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20Terminal('%3C%25%20else%20%25%3E')%2C%0A%20%20%20%20%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20)%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%0A%20%20)%0A)
 
 Diagram(
-Sequence(
-       Terminal('<%'),
-       Terminal('if'),
-       NonTerminal('expr'),
-       Terminal('%>'),
-       NonTerminal('block'),
-       ZeroOrMore(
-         Sequence(
-           Terminal('<% elif '),
-           NonTerminal('expr'),
-           Terminal('%>'),
-           NonTerminal('block'),
-         ),
-       ),
+ 
+       Stack(
+             Sequence(
+                   Terminal('<%'),
+                   Terminal('if'),
+                   NonTerminal('expr'),
+                   Terminal('%>'),
+             NonTerminal('block'),
+             ),
+               ZeroOrMore(
+                 Sequence(
+                   Terminal('<%'),Terminal('elif'),
+                   NonTerminal('expr'),
+                   Terminal('%>'),
+                   NonTerminal('block'),
+                 ),
+               ),
        Optional(
          Sequence(
            Terminal('<% else %>'),
            NonTerminal('block'),
          ),
-       ),
-       Terminal('<% end %>'),
-  )
+       )
+  ),
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
+ 
 )
 -------------------------
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('include')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20)%0A)
@@ -150,10 +284,38 @@ Sequence(
        Terminal('%>'),
    )
 )
+
+
+Diagram(
+ Stack(
+Sequence(
+       Terminal('<%'),
+       Terminal('include'),
+       Terminal('('),
+       NonTerminal('expr'),  
+       Optional(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal(')'),
+       Terminal('%>'),
+      
+   ),
+
+Sequence(  NonTerminal('block'),
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+)
+)
+
+
 -------------------------
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('extends')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
 
 Diagram(
+ Stack(
 Sequence(
        Terminal('<%'),
        Terminal('extends'),
@@ -167,10 +329,40 @@ Sequence(
        ),         
        Terminal(')'),
        Terminal('%>'),
-       NonTerminal('block'),
-       Terminal('<% end %>'), 
-   )
+      
+   ),
+ NonTerminal('block'),
+Sequence(
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
 )
+)
+)
+
+Diagram(
+ Stack(
+Sequence(
+       Terminal('<%'),
+       Terminal('extends'),
+       Terminal('('),
+       NonTerminal('expr'),  
+       Optional(
+          Sequence(
+            Terminal(','),
+            NonTerminal('expr'),
+          )
+       ),         
+       Terminal(')'),
+       Terminal('%>'),
+      
+   ),
+
+Sequence(  NonTerminal('block'),
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+)
+)
+
+
 -------------------------
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('with')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
 
@@ -194,20 +386,21 @@ Sequence(
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('template')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20Optional(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
 
 Diagram(
+ Stack(
 Sequence(
        Terminal('<%'),
        Terminal('template'),
+       Terminal('('),
        NonTerminal('expr'),  
-       Optional(
-          Sequence(
-            Terminal(','),
-            NonTerminal('expr'),
-          )
-       ),         
+       Terminal(')'),
        Terminal('%>'),
-       NonTerminal('block'),
-       Terminal('<% end %>'), 
-   )
+      
+   ),
+
+Sequence( NonTerminal('block'),
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
+)
 )
 -------------------------
 https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('require')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%20%20%0A%20%20%20%20%20%20%20ZeroOrMore(%0A%20%20%20%20%20%20%20%20%20%20Sequence(%0A%20%20%20%20%20%20%20%20%20%20%20%20Terminal('%2C')%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20)%2C%20%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%20%20%20%20%20%20%20NonTerminal('block')%2C%0A%20%20%20%20%20%20%20Terminal('%3C%25%20end%20%25%3E')%2C%20%0A%20%20%20)%0A)
@@ -225,7 +418,7 @@ Sequence(
        ),         
        Terminal('%>'),
        NonTerminal('block'),
-       Terminal('<% end %>'), 
+       Terminal('<%'), Terminal('end'), Terminal('%>'), 
    )
 )
 -------------------------
@@ -234,10 +427,15 @@ https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence
 
 Diagram(
 Sequence(
-       Terminal('<% ignorenl %>'),
-       NonTerminal('block'),
-       Terminal('<% end %>'), 
-   )
+       Terminal('<%'),
+       Terminal('ignorenl'),
+       Terminal('%>'),
+      
+   ),
+ NonTerminal('block'),
+Sequence(
+       Terminal('<%'),Terminal('end'),Terminal('%>'),
+)
 )
 -------------------------
 
@@ -328,3 +526,16 @@ Diagram(
 Diagram(
 )
 -------------------------
+https://tabatkins.github.io/railroad-diagrams/generator.html#Diagram(%0ASequence(%0A%20%20%20%20%20%20%20Terminal('%3C%25')%2C%0A%20%20%20%20%20%20%20Terminal('print')%2C%0A%20%20%20%20%20%20%20NonTerminal('var')%2C%0A%20%20%20%20%20%20%20Terminal('(')%2C%0A%20%20%20%20%20%20%20NonTerminal('expr')%2C%0A%20%20%20%20%20%20%20Terminal(')')%2C%0A%20%20%20%20%20%20%20Terminal('%25%3E')%2C%0A%0A%20%20)%0A)
+Diagram(
+Sequence(
+       Terminal('<%'),
+       Terminal('print'),
+       NonTerminal('var'),
+       Terminal('('),
+       NonTerminal('expr'),
+       Terminal(')'),
+       Terminal('%>'),
+
+  )
+)

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -33,6 +33,9 @@ This <% stmt %> test.
 The above example results in _'this is a test.'_ being output.
 
 ### assignment
+
+# ![](./images/stmt_assign.svg)
+
 Within a script block, you can create temporary variables for use within the template. Basic types such a string, boolean and numbers can be used.
 ```
 <% num := 123 %>

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -34,7 +34,7 @@ The above example results in _'this is a test.'_ being output.
 
 ### assignment
 
-# ![](./images/stmt_assign.svg)
+![assign](./images/stmt_assign.svg)
 
 Within a script block, you can create temporary variables for use within the template. Basic types such a string, boolean and numbers can be used.
 ```

--- a/docs/statements.md
+++ b/docs/statements.md
@@ -18,6 +18,10 @@ Copyright (c) 2019-2023 [Sempare Limited](http://www.sempare.ltd)
 
 ### print
 
+![print expr](./images/stmt_print_expr.svg)
+
+![print](./images/stmt_print.svg)
+
 Within a script, all text outside of the script _'<%'_ start and _'%>'_ end tokens is output.
 
 ```
@@ -32,6 +36,12 @@ This <% stmt %> test.
 ```
 The above example results in _'this is a test.'_ being output.
 
+You may also rely on the print() statement.
+
+```
+<% print('this is a test') %>
+```
+
 ### assignment
 
 ![assign](./images/stmt_assign.svg)
@@ -43,6 +53,8 @@ Within a script block, you can create temporary variables for use within the tem
 <% bool := false %>
 ```
 ### if
+
+![if](./images/stmt_if.svg)
 
 You may want to conditionally include content:
 ```
@@ -78,6 +90,8 @@ the list as at least one item
 
 ### for
 
+![for range](./images/stmt_for_range.svg)
+
 The _for to/downto_ loop comes in two forms as it does in Object Pascal:
 ```
 increasing integers from 1 to 10
@@ -100,6 +114,8 @@ You can change the _step_ interval as follows:
 <% end %>
 ```
 
+![for in](./images/stmt_for_in.svg)
+
 The other _for in_ variation is as follows:
 ```
 Attendees:
@@ -115,6 +131,8 @@ Attendees:
    <% i.name %> <% i.age %>
 <%end%> 
 ```
+
+![for in event](./images/stmt_for_in_event.svg)
 
 Further, there are _onbegin_, _onend_, _betweenitems_ and _onempty_ events that can be used.
 ```
@@ -195,6 +213,8 @@ Using for-in on TDataSet, the loop variable enumerates rows. The loop variable c
 
 ### while
 
+![while](./images/stmt_while.svg)
+
 While blocks are very flexibe looping constructs based on a boolean condition being true.
 
 ```
@@ -222,6 +242,9 @@ While loops may also have _offset_ and _limits_ defined:
    <% i := i + 1%>
 <% end %>
 ```
+
+![while events](./images/stmt_while_event.svg)
+
 While loops may also have _onbegin_, _onend_, _betweenitems_ and _onempty_ events defined:
 ```
 <% i := 1 %>
@@ -267,6 +290,8 @@ This will produce
 
 ### include
 
+![include](./images/stmt_include.svg)
+
 You may want to decompose templates into reusable parts. You register templates on a Template context. 
 
 ```
@@ -289,6 +314,8 @@ begin
 include() can also take a second parameter, allowing for improved scoping of variables, similar to the _with_ statement.
 
 ### with
+
+![with](./images/stmt_with.svg)
 
 The with() statement is used to localise variables from a nested structure.
 
@@ -322,6 +349,8 @@ The _with()_ statement will push all fields/properties in a record/class into a 
 
 ### template
 
+![template](./images/stmt_template.svg)
+
 Localised templates can also be defined locally within a template.
 
 The _include_() statement is used to render a local template as is the normal behaviour. Note that local templates take precedence over templates defined in a context when they are being resolved.
@@ -336,6 +365,8 @@ Using the TInfo structure above it could be appli
 ```
 
 ### require
+
+![require](./images/stmt_require.svg)
 
 The _require_() statement is used to validate that the input variable is of a particular type.
 
@@ -358,6 +389,8 @@ An exeption is thrown when the
 _require_ can take multiple parameters - in which case the input must match one of the types listed.
 
 ### ignorenl
+
+![ignorenl](./images/stmt_ignorenl.svg)
 
 The purpose of an _ignorenl_ block is to allow for template designers to space out content for easy maintenance, but to allow for the output to be more compact when required.
 
@@ -385,6 +418,8 @@ This would yield something like
 The _eoAllowIgnoreNL_ must be provided in the Context.Options or via Template.Eval() options.
 
 ### cycle
+
+![cycle](./images/stmt_cycle.svg)
 
 This allows for values to cycle when rendering content. e.g. 
 

--- a/tests/Sempare.Template.Test.pas
+++ b/tests/Sempare.Template.Test.pas
@@ -104,6 +104,11 @@ type
 
     [Test]
     procedure TestException;
+
+    [Test]
+    procedure TestDecimalEncodingErrorWithLists;
+    [Test]
+    procedure TestDecimalEncodingErrorWithParameters;
   end;
 
 type
@@ -387,6 +392,48 @@ begin
   ctx := Template.Context;
   ctx.Options := [eoStripRecurringSpaces, eoConvertTabsToSpaces];
   Assert.AreEqual(' hello world', Template.Eval(ctx, #9' hello '#9'  world'));
+end;
+
+procedure TTestTemplate.TestDecimalEncodingErrorWithLists;
+var
+  ctx: ITemplateContext;
+begin
+  ctx := Template.Context;
+  ctx.DecimalSeparator := ',';
+  Assert.AreEqual('', Template.Eval(ctx, '<% a := ["a"; "b"] %>'));
+  Assert.WillRaise(
+    procedure
+    begin // expecting ;
+      Assert.AreEqual('', Template.Eval(ctx, '<% a := ["a", "b"] %>'));
+    end);
+  ctx.DecimalSeparator := '.';
+  Assert.AreEqual('', Template.Eval(ctx, '<% a := ["a", "b"] %>'));
+  Assert.WillRaise(
+    procedure
+    begin // expecting ,
+      Assert.AreEqual('', Template.Eval(ctx, '<% a := ["a"; "b"] %>'));
+    end);
+end;
+
+procedure TTestTemplate.TestDecimalEncodingErrorWithParameters;
+var
+  ctx: ITemplateContext;
+begin
+  ctx := Template.Context;
+  ctx.DecimalSeparator := ',';
+  Assert.AreEqual('a b', Template.Eval(ctx, '<% fmt("%s %s"; "a"; "b") %>'));
+  Assert.WillRaise(
+    procedure
+    begin // expecting ;
+      Assert.AreEqual('', Template.Eval(ctx, '<% fmt("%s %s", "a", "b") %>'));
+    end);
+  ctx.DecimalSeparator := '.';
+  Assert.AreEqual('a b', Template.Eval(ctx, '<% fmt("%s %s", "a", "b")  %>'));
+  Assert.WillRaise(
+    procedure
+    begin // expecting ,
+      Assert.AreEqual('', Template.Eval(ctx, '<% fmt("%s %s"; "a"; "b")  %>'));
+    end);
 end;
 
 procedure TTestTemplate.TestDynamicLoader;


### PR DESCRIPTION
- Docs updated to include rail-road images of grammar.
- Doc updated to describe localisation around DecimalSeparator and ValueSeparator on ITemplateContext.
- Improved error messaging so that when ValueSeparator mismatch is made, it is reported correctly.