### PR TITLE
Allow ValueSeparator to be overridden

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,8 @@ Copyright (c) 2019-2023 [Sempare Limited](http://www.sempare.ltd)
 - [Dynamic Template Resolution](#Dynamic_Template_Resolution)
 - [Ignoring Whitespace With Multi-Line Statements](#Ignoring_Whitespace_With_Multi_Line_Statements)
 - [Options](#Options)
-- [Localisation of numbers](#Localisation_of_numbers)
+- [Decimal Separators](#Decimal_Separators)
+- [Value Separators](#Value_Separators)
 
 # Overview
 
@@ -161,21 +162,29 @@ The template engine allows for the following options:
 - eoPrettyPrint
   - use to review the parsed structure. output is to the console.
 
-### Localisation of numbers 
+### Decimal Separators
 
 Numbers are commonly formatted using comma and decimal point. e.g. 123.45
 
 However, in some regions, such as Germany, it the coma may be preferred. e.g. 123,45
 
-In order to accomodate this, the context configuration has a ValueSeperator and DecimalSeparator. These default based on locale.
+In order to accomodate this, the context configuration has a DecimalSeparator. These default based on locale.
 
-The DecimalSeparator may be set to '.' or ','. As a comma is commonly used to separate parameters, if the DecimalSeparator is ',', then the ValueSeparator becomes ';'.
+The DecimalSeparator may be set to '.' or ','. 
 
-The motivation for the behaviour is say we have:
+### Value Separators
+
+The ValueSeparator may be set to ',' or ';'. It must be explicity set.
+
+The motivation for the behaviour is to avoid any confusion with decimal separators.
 ```
-<% Add(1.23, 4.56) %>
+<% Add(1.23 , 4.56) %>
 ```
 When the DecimalSeparator is ',', then the ValueSeparator becomes ';' as illustrated:
 ```
-<% Add(1,23; 4,56) %>
+<% Add(1,23 ; 4,56) %>
+```
+However, the following does work:
+```
+<% Add(1,23 , 4,56) %>
 ```

--- a/src/Sempare.Template.Context.pas
+++ b/src/Sempare.Template.Context.pas
@@ -134,6 +134,7 @@ type
     procedure SetScriptEndStripToken(const Value: string);
     procedure SetScriptStartStripToken(const Value: string);
 
+    procedure SetValueSeparator(const ASeparator: char);
     function GetValueSeparator: char;
     function GetDecimalSeparator: char;
     procedure SetDecimalSeparator(const ASeparator: char);
@@ -158,7 +159,7 @@ type
     property StartStripToken: string read GetScriptStartStripToken write SetScriptStartStripToken;
     property EndStripToken: string read GetScriptEndStripToken write SetScriptEndStripToken;
 
-    property ValueSeparator: char read GetValueSeparator;
+    property ValueSeparator: char read GetValueSeparator write SetValueSeparator;
     property DecimalSeparator: char read GetDecimalSeparator write SetDecimalSeparator;
     property FormatSettings: TFormatSettings read GetFormatSettings;
     property DebugErrorFormat: string read GetDebugErrorFormat write SetDebugErrorFormat;
@@ -286,6 +287,7 @@ type
 
     function GetFormatSettings: TFormatSettings;
 
+    procedure SetValueSeparator(const ASeparator: char);
     procedure SetDecimalSeparator(const ASeparator: char);
 
     function GetDebugErrorFormat: string;
@@ -479,10 +481,6 @@ begin
   if not(FFormatSettings.DecimalSeparator in ['.', ',']) then
     raise ETemplate.CreateRes(@SDecimalSeparatorMustBeACommaOrFullStop);
 {$WARN WIDECHAR_REDUCED ON}
-  if FFormatSettings.DecimalSeparator = '.' then
-    FValueSeparator := ','
-  else
-    FValueSeparator := ';';
 end;
 
 procedure TTemplateContext.SetEncoding(const AEncoding: TEncoding);
@@ -510,6 +508,15 @@ end;
 procedure TTemplateContext.SetOptions(const AOptions: TTemplateEvaluationOptions);
 begin
   FOptions := AOptions;
+end;
+
+procedure TTemplateContext.SetValueSeparator(const ASeparator: char);
+begin
+{$WARN WIDECHAR_REDUCED OFF}
+  if not(ASeparator in [',', ';']) then
+    raise ETemplate.CreateRes(@SDecimalSeparatorMustBeACommaOrFullStop);
+{$WARN WIDECHAR_REDUCED ON}
+  FValueSeparator := ASeparator;
 end;
 
 procedure TTemplateContext.SetVariable(const AName: string; const AValue: TValue);

--- a/tests/Sempare.Template.TestLexer.pas
+++ b/tests/Sempare.Template.TestLexer.pas
@@ -83,6 +83,7 @@ var
 begin
   LContext := Template.Context();
   LContext.DecimalSeparator := ',';
+  LContext.ValueSeparator := ';';
   Assert.AreEqual('543,21', Template.Eval(LContext, '<% x:= 543,21 %><% x %>'));
   Assert.AreEqual('5,1234', Template.Eval(LContext, '<% x:= 5,1234 %><% x %>'));
   Assert.AreEqual('12,34 43,21 ', Template.Eval(LContext, '<% vals := [ 12,34 ; 43,21] %><% for x in vals %><% vals[x] %> <% end %>'));


### PR DESCRIPTION
Allow ValueSeparator to be overridden to be , or ;
Breaking change: ValueSeparator no longer changes to ; when DecimalSeparator is set to ,