### PR TITLE
1.7.3 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ lib
 iOSDevice32
 *.tvsconfig
 *.mes
+*.stat
+*.dcu

--- a/boss.json
+++ b/boss.json
@@ -1,7 +1,7 @@
 {
 	"name": "Sempare Template Engine",
 	"description": "Sempare Template Engine for Delphi allows for flexible text manipulation. It can be used for generating email, html, source code, xml, configuration, etc.",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"homepage": "https://github.com/sempare/sempare-delphi-template-engine",
 	"mainsrc": "./src/",
 	"projects": [],

--- a/src/Sempare.Template.Common.pas
+++ b/src/Sempare.Template.Common.pas
@@ -110,10 +110,19 @@ procedure RaiseError(const APositional: IPosition; const AFormat: string); overl
 procedure RaiseErrorRes(const APositional: IPosition; const ResStringRec: PResStringRec; const AArgs: array of const); overload;
 procedure RaiseErrorRes(const APositional: IPosition; const ResStringRec: PResStringRec); overload;
 
+function GetSempareVersion(): string;
+
 implementation
 
 uses
   Sempare.Template;
+
+{$INCLUDE 'Sempare.Template.Version.inc'}
+
+function GetSempareVersion(): string;
+begin
+  exit(format('%d.%d.%d', [MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION]));
+end;
 
 procedure AcceptVisitor(const ATemplate: ITemplate; const AVisitor: ITemplateVisitor); overload;
 begin

--- a/src/Sempare.Template.Common.pas
+++ b/src/Sempare.Template.Common.pas
@@ -66,6 +66,8 @@ type
     property Position: IPosition read FPosition write FPosition implements IPosition;
   end;
 
+  ETemplateVariableNotResolved = class(ETemplate);
+
   ITemplateVariables = interface
     ['{8C2D166D-2AC1-47AB-985E-2CFD5D44271D}']
     function GetItem(const AKey: string): TTemplateValue;

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -319,6 +319,10 @@ begin
     begin
       try
         LDeref := Deref(AExpr, LStackFrame.Root, AExpr.variable, eoRaiseErrorWhenVariableNotFound in FContext.Options, FContext, LDerefed);
+        if not LDerefed then
+        begin
+          LDerefed := FContext.TryGetVariable(AExpr.variable, LDeref);
+        end;
         if LDerefed then
           LValue := LDeref;
       except

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -72,6 +72,8 @@ type
     function EncodeVariable(const AValue: TValue): TValue;
     procedure CheckRunTime(const APosition: IPosition);
     function ExprListArgs(const AExprList: IExprList): TArray<TValue>;
+    function GetArgs(const APosition: IPosition; const AMethod: TRttiMethod; const AArgs: TArray<TValue>; const AContext: ITemplateContext): TArray<TValue>;
+    function DoInvoke(const APosition: IPosition; const AMethod: TRttiMethod; const AObject: TValue; const AArgs: TArray<TValue>; out AHasResult: boolean): TValue; overload;
     function Invoke(const AFuncCall: IFunctionCallExpr; const AArgs: TArray<TValue>; out AHasResult: boolean): TValue; overload;
     function Invoke(const AExpr: IMethodCallExpr; const AObject: TValue; const AArgs: TArray<TValue>; out AHasResult: boolean): TValue; overload;
     function EvalExpr(const AExpr: IExpr): TValue;
@@ -968,7 +970,7 @@ begin
   exit(AValue);
 end;
 
-function GetArgs(const APosition: IPosition; const AMethod: TRttiMethod; const AArgs: TArray<TValue>; const AContext: ITemplateContext): TArray<TValue>;
+function TEvaluationTemplateVisitor.GetArgs(const APosition: IPosition; const AMethod: TRttiMethod; const AArgs: TArray<TValue>; const AContext: ITemplateContext): TArray<TValue>;
 var
   LParameter: TRttiParameter;
   LParamIdx: integer;
@@ -981,18 +983,28 @@ begin
   LNumParams := length(LParams);
   LOffset := 0;
   setlength(result, LNumParams);
-  if (LNumParams > 0) and (LParams[0].ParamType.Handle = TypeInfo(ITemplateContext)) then
+  if (LNumParams > 0) then
   begin
-    result[0] := TValue.From<ITemplateContext>(AContext);
-    LOffset := 1;
+    if LParams[LOffset].ParamType.Handle = TypeInfo(ITemplateContext) then
+    begin
+      result[LOffset] := TValue.From<ITemplateContext>(AContext);
+      inc(LOffset);
+    end;
+    if LParams[LOffset].ParamType.Handle = TypeInfo(TObjectStack<TStackFrame>) then
+    begin
+      result[LOffset] := TValue.From < TObjectStack < TStackFrame >> (FStackFrames);
+      inc(LOffset);
+    end;
+
+    if LParams[LNumParams - 1].ParamType.TypeKind = tkDynArray then
+    begin
+      if LNumParams > 2 then
+        RaiseErrorRes(APosition, @STooManyParameters);
+      result[LOffset] := TValue.From(AArgs);
+      exit;
+    end;
   end;
-  if (LNumParams > 0) and (LParams[LNumParams - 1].ParamType.TypeKind = tkDynArray) then
-  begin
-    if LNumParams > 2 then
-      RaiseErrorRes(APosition, @STooManyParameters);
-    result[LOffset] := TValue.From(AArgs);
-    exit;
-  end;
+
   for LParamIdx := LOffset to LNumParams - 1 do
   begin
     LParameter := LParams[LParamIdx];
@@ -1031,13 +1043,7 @@ begin
       if GetParamCount = length(AArgs) then
         break;
   end;
-  AHasResult := LMethod.ReturnType <> nil;
-  if length(LMethod.GetParameters) = 0 then
-    result := LMethod.Invoke(nil, [])
-  else
-    result := LMethod.Invoke(nil, GetArgs(AFuncCall, LMethod, AArgs, FContext));
-  if result.IsType<TValue> then
-    result := result.AsType<TValue>();
+  exit(DoInvoke(AFuncCall, LMethod, nil, AArgs, AHasResult));
 end;
 
 procedure TEvaluationTemplateVisitor.Visit(const AExpr: IFunctionCallExpr);
@@ -1056,6 +1062,33 @@ begin
   end;
 end;
 
+function TEvaluationTemplateVisitor.DoInvoke(const APosition: IPosition; const AMethod: TRttiMethod; const AObject: TValue; const AArgs: TArray<TValue>; out AHasResult: boolean): TValue;
+
+  function GetParamCount: integer;
+  var
+    LParams: TArray<TRttiParameter>;
+    LParam: TRttiParameter;
+  begin
+    LParams := AMethod.GetParameters;
+    result := length(LParams);
+    if result > 0 then
+    begin
+      LParam := LParams[0];
+      if LParam.ParamType.Handle = TypeInfo(ITemplateContext) then
+        dec(result);
+    end;
+  end;
+
+begin
+  AHasResult := AMethod.ReturnType <> nil;
+  if length(AMethod.GetParameters) = 0 then
+    result := AMethod.Invoke(AObject, [])
+  else
+    result := AMethod.Invoke(AObject, GetArgs(APosition, AMethod, AArgs, FContext));
+  if result.IsType<TValue> then
+    result := result.AsType<TValue>();
+end;
+
 function TEvaluationTemplateVisitor.Invoke(const AExpr: IMethodCallExpr; const AObject: TValue; const AArgs: TArray<TValue>; out AHasResult: boolean): TValue;
 var
   LObjType: TRttiType;
@@ -1067,8 +1100,7 @@ begin
   LObject := AObject;
   if AObject.IsType<TValue> then
     LObject := AObject.AsType<TValue>;
-  AHasResult := LMethod.ReturnType <> nil;
-  exit(LMethod.Invoke(LObject, AArgs));
+  exit(DoInvoke(AExpr, LMethod, LObject, AArgs, AHasResult));
 end;
 
 function TEvaluationTemplateVisitor.ResolveTemplate(const APosition: IPosition; const AName: string): ITemplate;
@@ -1290,22 +1322,21 @@ end;
 
 procedure TEvaluationTemplateVisitor.Visit(const AExpr: IMapExpr);
 var
+  LMap: TMap;
+  LMapExpr: IMapExpr;
   LValue: TValue;
+  i: integer;
 begin
-  LValue := TValue.From<IMapExpr>(AExpr);
+  LMap := AExpr.GetMap.Clone;
+  LMapExpr := TMapExpr.Create(AExpr, LMap);
+  for i := 0 to LMap.Count - 1 do
+  begin
+    LValue := LMap.Values[i];
+    if LValue.IsType<IExpr> then
+      LMap.Values[i] := EvalExpr(LValue.AsType<IExpr>);
+  end;
+  LValue := TValue.From<IMapExpr>(LMapExpr);
   FEvalStack.push(LValue);
-end; {
- var
- LMap: TMap;
- i: integer;
- LValue: TValue;
- begin
- LMap := AExpr.getMap;
- for i := 0 to LMap.Count - 1 do
- begin
- LValue := LMap.Values[i];
- LMap.Values[i] := EvalExpr(LValue.AsType<IExpr>);
- end;
- end;  }
+end;
 
 end.

--- a/src/Sempare.Template.Functions.pas
+++ b/src/Sempare.Template.Functions.pas
@@ -234,6 +234,8 @@ type
     class procedure SetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AValue: TValue; const AStackOffset: integer); overload; static;
     class function StackDepth(const AStackFrames: TObjectStack<TStackFrame>): integer; static;
     class procedure SetMapValue(const AMap: TValue; const AKey: string; const AValue: TValue); static;
+
+    class function SempareVersion(): string; static;
   end;
 
 class function TInternalFuntions.Min(const AValue, BValue: double): double;
@@ -384,6 +386,11 @@ begin
     exit;
   LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
   LStackFrame[AVariable] := AValue;
+end;
+
+class function TInternalFuntions.SempareVersion: string;
+begin
+  exit(GetSempareVersion());
 end;
 
 class function TInternalFuntions.Sort(const AArray: TValue): TValue;
@@ -586,7 +593,7 @@ begin
   else if AString.Kind in [tkDynArray, tkArray] then
     exit(AString.GetArrayLength)
   else if MatchMap(AString.TypeInfo) then
-    exit(AString.AsType<TMap>.Count)
+    exit(AString.AsType<TMap>.count)
   else
     exit(-1);
 end;

--- a/src/Sempare.Template.Functions.pas
+++ b/src/Sempare.Template.Functions.pas
@@ -70,6 +70,7 @@ uses
   System.Generics.Collections,
   System.Generics.Defaults,
   Sempare.Template.ResourceStrings,
+  Sempare.Template.StackFrame,
   Sempare.Template.Common,
   Sempare.Template.Util,
   Sempare.Template.Rtti;
@@ -227,6 +228,12 @@ type
     class procedure Unmanage(const AContext: ITemplateContext; const AObject: TObject); static;
     class function ToJson(const AContext: ITemplateContext; const AValue: TValue): string; static;
     class function ParseJson(const AValue: string): TValue; static;
+    class function GetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string): TValue; overload; static;
+    class function GetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AStackOffset: integer): TValue; overload; static;
+    class procedure SetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AValue: TValue); overload; static;
+    class procedure SetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AValue: TValue; const AStackOffset: integer); overload; static;
+    class function StackDepth(const AStackFrames: TObjectStack<TStackFrame>): integer; static;
+    class procedure SetMapValue(const AMap: TValue; const AKey: string; const AValue: TValue); static;
   end;
 
 class function TInternalFuntions.Min(const AValue, BValue: double): double;
@@ -257,10 +264,12 @@ var
   LJsonStr: TJSonString absolute LJsonValue;
 
 begin
-  LJsonValue := TJsonObject.ParseJsonValue(AValue);
+  LJsonValue := TJSONObject.ParseJsonValue(AValue);
   try
     if LJsonValue is TJSonNumber then
-      exit(LJsonNum.AsDouble);
+    begin
+      exit(FloatToTValue(LJsonNum.AsDouble));
+    end;
     if LJsonValue is TJSonString then
       exit(LJsonStr.Value);
 {$IFDEF SUPPORT_JSON_BOOL}
@@ -353,6 +362,29 @@ begin
   exit(THashMD5.GetHashString(AStr));
 end;
 {$ENDIF}
+
+class procedure TInternalFuntions.SetMapValue(const AMap: TValue; const AKey: string; const AValue: TValue);
+var
+  LMap: IMapExpr;
+begin
+  LMap := AMap.AsType<IMapExpr>();
+  LMap.GetMap.Items[AKey] := AValue;
+end;
+
+class procedure TInternalFuntions.SetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AValue: TValue);
+begin
+  SetVariable(AStackFrames, AVariable, AValue, -1);
+end;
+
+class procedure TInternalFuntions.SetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AValue: TValue; const AStackOffset: integer);
+var
+  LStackFrame: TStackFrame;
+begin
+  if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
+    exit;
+  LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
+  LStackFrame[AVariable] := AValue;
+end;
 
 class function TInternalFuntions.Sort(const AArray: TValue): TValue;
 
@@ -449,7 +481,12 @@ begin
   if IsStr(AValue) then
     exit(AsString(AValue, AContext));
   if IsNumLike(AValue) then
-    exit(FloatToStr(AsNum(AValue, AContext)));
+  begin
+    if IsIntLike(AValue) then
+      exit(IntToStr(trunc(AValue.AsExtended)))
+    else
+      exit(FloatToStr(AValue.AsExtended));
+  end;
   if IsBool(AValue) then
     exit(BoolToStr(AsBoolean(AValue), true).ToLower);
   if AValue.IsType<TMap> then
@@ -646,6 +683,21 @@ begin
   exit(FormatDateTime(AFormat, ADateTime));
 end;
 
+class function TInternalFuntions.GetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string; const AStackOffset: integer): TValue;
+var
+  LStackFrame: TStackFrame;
+begin
+  if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
+    exit;
+  LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
+  exit(LStackFrame[AVariable]);
+end;
+
+class function TInternalFuntions.GetVariable(const AStackFrames: TObjectStack<TStackFrame>; const AVariable: string): TValue;
+begin
+  exit(GetVariable(AStackFrames, AVariable, -1));
+end;
+
 {$IFDEF SUPPORT_URL_FORM_ENCODING}
 
 class function TInternalFuntions.FormDecode(const AStr: string): string;
@@ -744,6 +796,13 @@ begin
   exit(Split(AString, ' '));
 end;
 
+class function TInternalFuntions.StackDepth(const AStackFrames: TObjectStack<TStackFrame>): integer;
+begin
+  if (AStackFrames = nil) then
+    exit(-1);
+  exit(AStackFrames.count);
+end;
+
 class function TInternalFuntions.StartsWith(const AString, ASearch: string; const AIgnoreCase: boolean): boolean;
 begin
   exit(AString.StartsWith(ASearch, AIgnoreCase));
@@ -812,7 +871,7 @@ end;
 
 class function TInternalFuntions.IsInt(const AValue: TValue): boolean;
 begin
-  exit(isIntLike(AValue));
+  exit(IsIntLike(AValue));
 end;
 
 class function TInternalFuntions.IsMap(const AValue: TValue): boolean;
@@ -863,7 +922,7 @@ end;
 
 function TTemplateFunctions.GetIsEmpty: boolean;
 begin
-  exit(FFunctions.Count > 0);
+  exit(FFunctions.count > 0);
 end;
 
 procedure TTemplateFunctions.RegisterDefaults;

--- a/src/Sempare.Template.ResourceStrings.pas
+++ b/src/Sempare.Template.ResourceStrings.pas
@@ -77,6 +77,7 @@ resourcestring
   SInvalidCharacterDetected = 'Invalid character detected';
   SRefreshTooFrequent = 'Template refresh too frequent';
   SAssignmentToVar = 'Assignment to variables only';
+  SVariableNotResolved = 'Variable %s not resolved';
 
 implementation
 

--- a/src/Sempare.Template.StackFrame.pas
+++ b/src/Sempare.Template.StackFrame.pas
@@ -56,6 +56,7 @@ type
     function Clone(const ARecord: TValue): TStackFrame; overload;
     function Root: TValue;
     property Item[const AKey: string]: TValue read GetItem write SetItem; default;
+    property Parent: TStackFrame read FParent;
   end;
 
 implementation

--- a/src/Sempare.Template.Version.inc
+++ b/src/Sempare.Template.Version.inc
@@ -1,3 +1,3 @@
 const MAJOR_VERSION=1;
 const MINOR_VERSION=7;
-const PATCH_VERSION=2;
+const PATCH_VERSION=3;

--- a/src/Sempare.Template.pas
+++ b/src/Sempare.Template.pas
@@ -301,7 +301,7 @@ end;
 
 class function Template.Version: string;
 begin
-  exit(format('%d.%d.%d', [MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION]));
+  exit(GetSempareVersion());
 end;
 
 class procedure Template.Eval(const AContext: ITemplateContext; const ATemplate: string; const AStream: TStream);

--- a/src/Sempare.Template.pas
+++ b/src/Sempare.Template.pas
@@ -79,18 +79,14 @@ type
   TTemplateRegistry = Sempare.Template.TemplateRegistry.TTemplateRegistry;
   TTemplateLoadStrategy = Sempare.Template.TemplateRegistry.TTemplateLoadStrategy;
   TSempareServerPages = TTemplateRegistry;
-  ETemplateNotResolved = Sempare.Template.TemplateRegistry.ETemplateNotResolved;
   TTempateLogMessage = Sempare.Template.TemplateRegistry.TTempateLogMessage;
+
+  ETemplateNotResolved = Sempare.Template.TemplateRegistry.ETemplateNotResolved;
+  ETemplateEvaluationError = Sempare.Template.Common.ETemplateEvaluationError;
+  ETemplateVariableNotResolved = Sempare.Template.Common.ETemplateVariableNotResolved;
 
   Template = class
 {$INCLUDE 'Sempare.Template.Version.inc'}
-{$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
-{$IFDEF MSWINDOWS}
-  private
-    class var FLicenseShown: boolean;
-    class procedure Initialize;
-{$ENDIF}
-{$ENDIF}
   public
     class function Context(const AOptions: TTemplateEvaluationOptions = [eoOptimiseTemplate]): ITemplateContext; inline; static;
     class function Parser(const AContext: ITemplateContext): ITemplateParser; overload; inline; static;
@@ -176,11 +172,6 @@ type
 implementation
 
 uses
-{$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
-{$IFDEF MSWINDOWS}
-  VCL.Dialogs,
-{$ENDIF}
-{$ENDIF}
   System.Rtti,
   Sempare.Template.Evaluate,
   Sempare.Template.VariableExtraction,
@@ -449,20 +440,23 @@ var
   LTemplateVisitor: IEvaluationTemplateVisitor;
   LResolveContext: TTemplateValue;
   LValue: TTemplateValue;
+{$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
+  LConfirmLicense: TStringStream;
+{$ENDIF}
 begin
 {$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
-{$IFDEF MSWINDOWS}
-  if not FLicenseShown then
-  begin
-    ShowMessage( //
-      'Thank you for trying the Sempare Template Engine.'#13#10#13#10 + //
-      'To supress this message, set the conditional define SEMPARE_TEMPLATE_CONFIRM_LICENSE in the project options.'#13#10#13#10 + //
-      'Please remember the library is dual licensed. You are free to use it under the GPL or you can support the project to keep it alive as per:'#13#10#13#10 + //
-      'https://github.com/sempare/sempare-delphi-template-engine/blob/main/docs/commercial.license.md' //
-      );
-    FLicenseShown := true;
+  LConfirmLicense := TStringStream.Create('Thank you for trying the Sempare Template Engine.'#13#10#13#10 + //
+    'To supress this message, set the conditional define SEMPARE_TEMPLATE_CONFIRM_LICENSE in the project options.'#13#10#13#10#13#10 + //
+    'Please remember the library is dual licensed. This is open source - Free as in speech, not Free as in beer. You are free to use it under conditions of the GPL or you can support the project with a commercial license to keep it alive as per:'#13#10#13#10#13#10 + //
+    'https://github.com/sempare/sempare-delphi-template-engine/blob/main/docs/commercial.license.md'#13#10#13#10#13#10 + //
+    'NOTE: Downloading the Sempare Template Engine through GetIt does not mean you are exempt of licensing for commercial use.'#13#10#13#10#13#10 //
+    );
+  try
+    LConfirmLicense.Position := 0;
+    AStream.CopyFrom(LConfirmLicense);
+  finally
+    LConfirmLicense.Free;
   end;
-{$ENDIF}
 {$ENDIF}
   LResolveContext := AResolveContext;
   if LResolveContext.IsType<TTemplateValue> then
@@ -512,16 +506,6 @@ begin
   AFunctions := LExtractionVisitor.Functions;
 end;
 
-{$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
-{$IFDEF MSWINDOWS}
-
-class procedure Template.Initialize;
-begin
-  FLicenseShown := false;
-end;
-{$ENDIF}
-{$ENDIF}
-
 class function Template.Eval(const AContext: ITemplateContext; const ATemplate: ITemplate): string;
 begin
   exit(Eval(AContext, ATemplate, ''));
@@ -538,15 +522,5 @@ class function TEncodingHelper.GetUTF8WithoutBOM: TEncoding;
 begin
   exit(GUTF8WithoutPreambleEncoding);
 end;
-
-initialization
-
-{$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
-{$IFDEF MSWINDOWS}
-  Template.Initialize;
-{$ENDIF}
-{$ENDIF}
-
-finalization
 
 end.

--- a/tests/Sempare.Template.Test.pas
+++ b/tests/Sempare.Template.Test.pas
@@ -127,6 +127,9 @@ type
 
     [Test]
     procedure TestPassingTValue;
+
+    [Test]
+    procedure TestVariableResolver;
   end;
 
 type
@@ -869,6 +872,24 @@ begin
     begin // expects  abc
       Assert.AreEqual('', Template.Eval(LCtx, '<% abc %>'));
     end);
+end;
+
+procedure TTestTemplate.TestVariableResolver;
+var
+  LCtx: ITemplateContext;
+begin
+  LCtx := Template.Context();
+  LCtx.VariableResolver := function(const AContext: ITemplateContext; const AName: string; out AResult: TValue): boolean
+    begin
+      if AName = 'somevar' then
+      begin
+        AResult := 'value';
+        exit(true);
+      end;
+      exit(false);
+    end;
+  Assert.AreEqual('', Template.Eval(LCtx, '<% avar %>'));
+  Assert.AreEqual('value', Template.Eval(LCtx, '<% somevar %>'));
 end;
 
 procedure TTestTemplate.TestVersionPresent;

--- a/tests/Sempare.Template.TestFunctions.pas
+++ b/tests/Sempare.Template.TestFunctions.pas
@@ -129,6 +129,8 @@ type
     procedure TestIsEmpty;
     [Test]
     procedure TestManaged;
+    [Test]
+    procedure TestVersion;
   end;
 
 type
@@ -628,6 +630,11 @@ begin
   Assert.AreEqual('managed', Template.Eval('<% manage(_).value %><% unmanage(_) %><% _.Free() %>', LClass));
   Assert.IsTrue(LDestroyed);
 
+end;
+
+procedure TFunctionTest.TestVersion;
+begin
+  Assert.AreEqual(Template.Version, Template.Eval('<% SempareVersion() %>'));
 end;
 
 initialization

--- a/tests/Sempare.Template.TestMap.pas
+++ b/tests/Sempare.Template.TestMap.pas
@@ -66,6 +66,9 @@ type
 
     [Test]
     procedure TestParseJson;
+
+    [test]
+    procedure TestMapWithExpression;
   end;
 
 implementation
@@ -98,6 +101,11 @@ begin
 
   Assert.AreEqual('123', Template.Eval('<% map := { "a": false } %><% map := { "a": 123 } %><% print(map.a) %>'));
 
+end;
+
+procedure TTestTemplateMap.TestMapWithExpression;
+begin
+  Assert.AreEqual('false, 129', Template.Eval('<% map := { "a": true and false, "b": 123 + 6 } %><% map.a %>, <% map.b %>'));
 end;
 
 procedure TTestTemplateMap.TestParseJson;


### PR DESCRIPTION
NEW: add some helper debug methods for probing the stack frames
NEW: add Context.VariableResolver
FIX: general refactorings
NEW: map values can now contain expressions
FIX: VCL dependency removed. Introductory licensing text is now included in template output when first run without the define.
FIX: refactor SempareVersion() helper