### PR TITLE
#175 - release mode should force compiler to stop if license is not confirmed

### DIFF
--- a/src/Sempare.Template.pas
+++ b/src/Sempare.Template.pas
@@ -444,6 +444,11 @@ var
   LConfirmLicense: TStringStream;
 {$ENDIF}
 begin
+{$IFDEF RELEASE}
+  {$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE }
+    {$MESSAGE FATAL 'The SEMPARE_TEMPLATE_CONFIRM_LICENSE define must be set in RELEASE mode.'}
+  {$ENDIF}
+{$ENDIF}
 {$IFNDEF SEMPARE_TEMPLATE_CONFIRM_LICENSE}
   LConfirmLicense := TStringStream.Create('Thank you for trying the Sempare Template Engine.'#13#10#13#10 + //
     'To supress this message, set the conditional define SEMPARE_TEMPLATE_CONFIRM_LICENSE in the project options.'#13#10#13#10#13#10 + //


### PR DESCRIPTION
For release mode, have the compiler fail so that the license message doesn't make its way into production accidentally.

Fixed based on client request.