### PR TITLE
Fix xe7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/DUnitX"]
+	path = thirdparty/DUnitX
+	url = git@github.com:VSoftTechnologies/DUnitX.git

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![platform compatibility](https://img.shields.io/badge/platform-Android32%20%7C%20Android64%20%7C%20Linux64%20%7C%20macOS64%20%7C%20Win32%20%7C%20Win64-lightgrey)
 ![license](https://img.shields.io/github/license/sempare/sempare-delphi-template-engine) 
 
-[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev&label=dev+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
-[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main&label=main+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
+[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev&label=dev+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml?label=dev+branch)
+[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main&label=main+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml?label=main+branch)
 
 
 # ![](./images/sempare-logo-45px.png) Sempare Template Engine

--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 ![platform compatibility](https://img.shields.io/badge/platform-Android32%20%7C%20Android64%20%7C%20Linux64%20%7C%20macOS64%20%7C%20Win32%20%7C%20Win64-lightgrey)
 ![license](https://img.shields.io/github/license/sempare/sempare-delphi-template-engine) 
 
-[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev&label=dev+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml?label=dev+branch)
-[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main&label=main+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml?label=main+branch)
-
-
 # ![](./images/sempare-logo-45px.png) Sempare Template Engine
 
 Copyright (c) 2019-2024 [Sempare Limited](http://www.sempare.ltd)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 ![platform compatibility](https://img.shields.io/badge/platform-Android32%20%7C%20Android64%20%7C%20Linux64%20%7C%20macOS64%20%7C%20Win32%20%7C%20Win64-lightgrey)
 ![license](https://img.shields.io/github/license/sempare/sempare-delphi-template-engine) 
 
-[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
-[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
+[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev&label=dev+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
+[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main&label=main+branch)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
 
 
 # ![](./images/sempare-logo-45px.png) Sempare Template Engine

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ![platform compatibility](https://img.shields.io/badge/platform-Android32%20%7C%20Android64%20%7C%20Linux64%20%7C%20macOS64%20%7C%20Win32%20%7C%20Win64-lightgrey)
 ![license](https://img.shields.io/github/license/sempare/sempare-delphi-template-engine) 
 
+[![dev branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=dev)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
+[![main branch](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml/badge.svg?branch=main)](https://github.com/sempare/sempare-delphi-template-engine/actions/workflows/delphi-package.yml)
+
 
 # ![](./images/sempare-logo-45px.png) Sempare Template Engine
 

--- a/Sempare.Template.Tester.dproj
+++ b/Sempare.Template.Tester.dproj
@@ -45,11 +45,11 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
-        <DCC_UnitSearchPath>$(DUnitX);src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>thirdparty\DUnitX\Source;$(DUnitX);src;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
         <SanitizedProjectName>Sempare_Template_Tester</SanitizedProjectName>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
-        <DCC_UsePackage>DBXSqliteDriver;RESTComponents;vclFireDAC;tethering;FireDACADSDriver;vcltouch;vcldb;bindcompfmx;inetdb;fmx;FireDACIBDriver;fmxdae;vquery260;dacvcl260;dbexpress;vclx;dsnap;FireDACCommon;RESTBackendComponents;VCLRESTComponents;soapserver;vclie;bindengine;DBXMySQLDriver;CloudService;FireDACMySQLDriver;FireDACCommonDriver;inet;bindcompdbx;vcl;ADODataProvider;dsnapcon;FireDACDataProvider;FireDACMSAccDriver;vclimg;FireDAC;DBXDataProvider;FireDACSqliteDriver;FireDACPgDriver;crcontrols260;soaprtl;DbxCommonDriver;xmlrtl;soapmidas;fmxobj;vclwinx;dac260;rtl;DbxClientDriver;CustomIPTransport;vcldsnap;DOSCommandDR;bindcomp;appanalytics;bindcompvcl;dbxcds;adortl;dsnapxml;dbrtl;inetdbxpress;fmxase;$(DCC_UsePackage)</DCC_UsePackage>
+        <DCC_UsePackage>$(DCC_UsePackage)</DCC_UsePackage>
         <DCC_Namespace>Winapi;System.Win;Data.Win;Datasnap.Win;Web.Win;Soap.Win;Xml.Win;Bde;$(DCC_Namespace)</DCC_Namespace>
         <BT_BuildType>Debug</BT_BuildType>
         <VerInfo_Keys>CompanyName=;FileDescription=$(MSBuildProjectName);FileVersion=1.5.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProgramID=ltd.sempare.$(MSBuildProjectName);ProductName=$(MSBuildProjectName);ProductVersion=1.5.0.0;Comments=</VerInfo_Keys>

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -523,7 +523,7 @@ var
       RaiseErrorRes(AStmt, @SValueIsNotEnumerable);
     LEnumObj := LEnumValue.AsObject;
     try
-      LLoopExprType := FContext.RttiContext.GetType(LEnumObj.ClassType);
+      LLoopExprType := FContext.RttiContext().GetType(LEnumObj.ClassType);
       LEnumMoveNextMethod := LLoopExprType.GetMethod('MoveNext');
       LEnumCurrentProperty := LLoopExprType.getProperty('Current');
       LRaiseIfMissing := eoRaiseErrorWhenVariableNotFound in FContext.Options;
@@ -662,7 +662,7 @@ begin
   try
     if not LLoopExpr.IsEmpty then
     begin
-      LLoopExprType := FContext.RttiContext.GetType(LLoopExpr.TypeInfo);
+      LLoopExprType := FContext.RttiContext().GetType(LLoopExpr.TypeInfo);
 
       case LLoopExprType.TypeKind of
         tkInterface:
@@ -1113,7 +1113,7 @@ var
   LObject: TValue;
   LMethod: TRttiMethod;
 begin
-  LObjType := FContext.RttiContext.GetType(AObject.TypeInfo);
+  LObjType := FContext.RttiContext().GetType(AObject.TypeInfo);
   LMethod := LObjType.GetMethod(AExpr.Method);
   LObject := AObject;
   if AObject.IsType<TValue> then
@@ -1197,7 +1197,7 @@ var
 begin
   if HasBreakOrContinue then
     exit;
-  LInputType := FContext.RttiContext.GetType(FStackFrames.peek['_'].TypeInfo).Name.ToLower;
+  LInputType := FContext.RttiContext().GetType(FStackFrames.peek['_'].TypeInfo).Name.ToLower;
   LExprs := ExprListArgs(AStmt.exprlist);
   if length(LExprs) = 0 then
     exit;

--- a/src/Sempare.Template.Functions.pas
+++ b/src/Sempare.Template.Functions.pas
@@ -139,7 +139,7 @@ var
   LClassType: TRttiType;
   LMethod: TRttiMethod;
 begin
-  LClassType := FContext.RttiContext.GetType(AClass);
+  LClassType := FContext.RttiContext().GetType(AClass);
   for LMethod in LClassType.GetMethods do
     Add(LMethod);
 end;
@@ -385,7 +385,11 @@ var
 begin
   if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
     exit;
+  {$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
   LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
+  {$ELSE}
+  LStackFrame := AStackFrames.ToArray[AStackFrames.count + AStackOffset];
+  {$ENDIF}
   LStackFrame[AVariable] := AValue;
 end;
 
@@ -532,7 +536,7 @@ var
   lpos: integer;
 begin
   try
-    exit(AContext.RttiContext.GetType(AValue.AsType<TValue>.TypeInfo).QualifiedName);
+    exit(AContext.RttiContext().GetType(AValue.AsType<TValue>.TypeInfo).QualifiedName);
   except
     on e: exception do
     begin
@@ -702,7 +706,11 @@ var
 begin
   if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
     exit;
+  {$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
   LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
+  {$ELSE}
+  LStackFrame := AStackFrames.ToArray[AStackFrames.count + AStackOffset];
+  {$ENDIF}
   exit(LStackFrame[AVariable]);
 end;
 
@@ -829,7 +837,7 @@ begin
   end;
   if LIsRecord or LIsObject then
   begin
-    LType := AContext.RttiContext.GetType(AValue.TypeInfo);
+    LType := AContext.RttiContext().GetType(AValue.TypeInfo);
     LField := LType.GetField('id');
     LPtr := GetPtr;
     if LField <> nil then

--- a/src/Sempare.Template.Rtti.pas
+++ b/src/Sempare.Template.Rtti.pas
@@ -209,7 +209,7 @@ var
       RaiseError(APosition, SValueIsNotEnumerable);
     LEnumObject := LValue.AsObject;
     try
-      TRightType := AContext.RttiContext.GetType(LEnumObject.ClassType);
+      TRightType := AContext.RttiContext().GetType(LEnumObject.ClassType);
       LEnumMoveNextMethod := TRightType.GetMethod('MoveNext');
       LEnumCurrentProperty := TRightType.GetProperty('Current');
       while LEnumMoveNextMethod.Invoke(LEnumObject, []).AsBoolean do
@@ -300,7 +300,7 @@ begin
   result := false;
   if not IsEnumerable(AContext, ARight) and not MatchMap(AContext, ARight) then
     RaiseError(APosition, SValueIsNotEnumerableOrMap);
-  TRightType := AContext.RttiContext.GetType(ARight.TypeInfo);
+  TRightType := AContext.RttiContext().GetType(ARight.TypeInfo);
   case TRightType.TypeKind of
     tkInterface:
       VisitInterface;
@@ -323,7 +323,7 @@ begin
     tkDynArray, tkArray:
       exit(true);
     tkClass, tkClassRef:
-      exit(AContext.RttiContext.GetType(AValue.TypeInfo).GetMethod('GetEnumerator') <> nil);
+      exit(AContext.RttiContext().GetType(AValue.TypeInfo).GetMethod('GetEnumerator') <> nil);
   else
     exit(false);
   end;
@@ -480,7 +480,7 @@ begin
       if AValue.TypeInfo = TypeInfo(TValue) then
         exit(AsString(AValue.AsType<TValue>(), AContext))
       else
-        exit(AContext.RttiContext.GetType(AValue.TypeInfo).Name);
+        exit(AContext.RttiContext().GetType(AValue.TypeInfo).Name);
   else
     exit('');
   end;
@@ -515,7 +515,7 @@ var
 begin
   // Ideally wuld like to use TryGetItem, but couldn't get it working
   // with TValue result...
-  LObjectType := AContext.RttiContext.GetType(AObj.TypeInfo);
+  LObjectType := AContext.RttiContext().GetType(AObj.TypeInfo);
   LContainsKeyMethod := LObjectType.GetMethod('ContainsKey');
   try
     if not LContainsKeyMethod.Invoke(AObj, [ADeref]).AsBoolean then
@@ -607,7 +607,7 @@ begin
       end;
     end;
   end;
-  exit(TryGetFieldOrProperty(obj.AsObject, AContext.RttiContext.GetType(obj.TypeInfo), ADeref, AContext, AResult));
+  exit(TryGetFieldOrProperty(obj.AsObject, AContext.RttiContext().GetType(obj.TypeInfo), ADeref, AContext, AResult));
 end;
 
 function TryDerefList(const APosition: IPosition; const AObj: TValue; const ADeref: TValue; const ARaiseIfMissing: boolean; const AContext: ITemplateContext; out AResult: TValue): boolean;
@@ -616,7 +616,7 @@ var
   LProperty: TRttiProperty;
   LIndexedProperty: TRttiIndexedProperty;
 begin
-  LType := AContext.RttiContext.GetType(AObj.TypeInfo);
+  LType := AContext.RttiContext().GetType(AObj.TypeInfo);
   try
     if IsIntLike(ADeref) then
     begin
@@ -656,7 +656,7 @@ var
   LIndexedProperty: TRttiIndexedProperty;
   LDerefValue: TValue;
 begin
-  LType := AContext.RttiContext.GetType(AObj.TypeInfo);
+  LType := AContext.RttiContext().GetType(AObj.TypeInfo);
   try
     if IsStrLike(ADeref) then
     begin
@@ -868,7 +868,7 @@ function TryDeref(const APosition: IPosition; const AVar, ADeref: TValue; const 
     LMax: int64;
   begin
     LIndex := AsInt(ADeref, AContext);
-    LElementType := AContext.RttiContext.GetType(AObj.TypeInfo) as TRttiArrayType;
+    LElementType := AContext.RttiContext().GetType(AObj.TypeInfo) as TRttiArrayType;
     LArrayDimType := LElementType.Dimensions[0];
     LMin := 0;
     if LArrayDimType <> nil then
@@ -908,7 +908,7 @@ function TryDeref(const APosition: IPosition; const AVar, ADeref: TValue; const 
         exit(true);
     end;
 
-    exit(TryGetFieldOrProperty(LObj.GetReferenceToRawData, AContext.RttiContext.GetType(AObj.TypeInfo), ADeref, AContext, AResult));
+    exit(TryGetFieldOrProperty(LObj.GetReferenceToRawData, AContext.RttiContext().GetType(AObj.TypeInfo), ADeref, AContext, AResult));
   end;
 
   function TryDerefInterface(const AObj: TValue; const ADeref: TValue; out AResult: TValue): boolean;
@@ -1047,7 +1047,9 @@ begin
     (ATypeInfo = TypeInfo(TJSONNull)) or //
     (ATypeInfo = TypeInfo(TJSONNumber)) or //
     (ATypeInfo = TypeInfo(TJSONString)) or //
+    {$IFDEF SUPPORT_JSON_BOOL}
     (ATypeInfo = TypeInfo(TJSONBool)) or //
+    {$ENDIF}
     (ATypeInfo = TypeInfo(TJSONTrue)) or //
     (ATypeInfo = TypeInfo(TJSONFalse)) //
     );
@@ -1116,7 +1118,7 @@ begin
   LMethod := ARttiType.GetMethod('GetEnumerator');
   LEnumObject := LMethod.Invoke(LDictionary, []).AsObject;
   try
-    LEnumType := AContext.RttiContext.GetType(LEnumObject.ClassType);
+    LEnumType := AContext.RttiContext().GetType(LEnumObject.ClassType);
     LEnumMoveNextMethod := LEnumType.GetMethod('MoveNext');
     LEnumCurrentProperty := LEnumType.GetProperty('Current');
     LPairKeyField := nil;
@@ -1127,7 +1129,7 @@ begin
       LPairRecordPtr := LEnumPair.GetReferenceToRawData;
       if LPairKeyField = nil then
       begin
-        LEnumType := AContext.RttiContext.GetType(LEnumPair.TypeInfo);
+        LEnumType := AContext.RttiContext().GetType(LEnumPair.TypeInfo);
         LPairKeyField := LEnumType.GetField('Key');
         LPairValueField := LEnumType.GetField('Value');
       end;
@@ -1156,7 +1158,7 @@ var
 begin
   if AObject = nil then
     exit(true);
-  LType := AContext.RttiContext.GetType(AObject.ClassType);
+  LType := AContext.RttiContext().GetType(AObject.ClassType);
   LCountProp := LType.GetProperty('RecordCount');
   LCount := LCountProp.GetValue(AObject).AsInteger;
   exit(LCount = 0);
@@ -1168,7 +1170,7 @@ var
   LCount: integer;
   LCountProp: TRttiMethod;
 begin
-  LType := AContext.RttiContext.GetType(AObject.TypeInfo);
+  LType := AContext.RttiContext().GetType(AObject.TypeInfo);
   LCountProp := LType.GetMethod('GetCount');
   LCount := LCountProp.Invoke(AObject, []).AsInteger;
   exit(LCount = 0);
@@ -1182,7 +1184,7 @@ var
 begin
   if AObject = nil then
     exit(true);
-  LType := AContext.RttiContext.GetType(AObject.ClassType);
+  LType := AContext.RttiContext().GetType(AObject.ClassType);
   LCountProp := LType.GetProperty('Count');
   LCount := LCountProp.GetValue(AObject).AsInteger;
   exit(LCount = 0);

--- a/src/Sempare.Template.pas
+++ b/src/Sempare.Template.pas
@@ -458,7 +458,7 @@ begin
     );
   try
     LConfirmLicense.Position := 0;
-    AStream.CopyFrom(LConfirmLicense);
+    AStream.CopyFrom(LConfirmLicense, LConfirmLicense.Size);
   finally
     LConfirmLicense.Free;
   end;


### PR DESCRIPTION
RttiContext needed to be referenced with parenthesis
TJsonBool required the compiler directive check
Stream.CopyFrom() requires a size in older versions

#196 fixed