### PR TITLE
Simpler whitespace support #147

### DIFF
--- a/demo/SempareTemplatePlayground/Sempare.Template.PlaygroundForm.pas
+++ b/demo/SempareTemplatePlayground/Sempare.Template.PlaygroundForm.pas
@@ -136,11 +136,13 @@ type
     procedure butExtractVarsClick(Sender: TObject);
   private
     { Private declarations }
+    FLastContent: string;
     FEncoding: TEncoding;
     FContext: ITemplateContext;
     FTemplate: ITemplate;
     FFilename: string;
-    Finit: boolean;
+    FInit: boolean;
+    FForce: boolean;
     procedure Process;
     procedure GridPropsToContext;
     procedure WriteTmpHtml;
@@ -248,21 +250,29 @@ end;
 procedure TFormTemplateEnginePlayground.cbConvertTabsToSpacesClick(Sender: TObject);
 begin
   SetOption(cbConvertTabsToSpaces.Checked, eoConvertTabsToSpaces);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbEvalEarlyClick(Sender: TObject);
 begin
   SetOption(cbEvalEarly.Checked, eoEvalEarly);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbEvalVarsEarlyClick(Sender: TObject);
 begin
   SetOption(cbEvalVarsEarly.Checked, eoEvalVarsEarly);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbFlattenTemplateClick(Sender: TObject);
 begin
   SetOption(cbFlattenTemplate.Checked, eoFlattenTemplate);
+  FForce := true;
+  Eval;
 end;
 
 function DefaultEncoder(const AValue: string): string;
@@ -276,6 +286,7 @@ begin
     FContext.UseHtmlVariableEncoder
   else
     FContext.VariableEncoder := DefaultEncoder;
+  FForce := true;
   Eval;
 end;
 
@@ -284,26 +295,36 @@ begin
   SetOption(cbOptimiseTemplate.Checked, eoOptimiseTemplate);
   if cbOptimiseTemplate.Checked then
     cbFlattenTemplate.Checked := true;
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbRaiseErrorWhenVariableNotFoundClick(Sender: TObject);
 begin
   SetOption(cbRaiseErrorWhenVariableNotFound.Checked, eoRaiseErrorWhenVariableNotFound);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbStripRecurringNewlinesClick(Sender: TObject);
 begin
   SetOption(cbStripRecurringNewlines.Checked, eoStripRecurringNewlines);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbStripRecurringSpacesClick(Sender: TObject);
 begin
   SetOption(cbStripRecurringSpaces.Checked, eoStripRecurringSpaces);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbTrimLinesClick(Sender: TObject);
 begin
   SetOption(cbTrimLines.Checked, eoTrimLines);
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbUseCustomScriptTagsClick(Sender: TObject);
@@ -320,12 +341,15 @@ begin
     FContext.NewLine := '<br>'#13#10
   else
     FContext.NewLine := #13#10;
+  FForce := true;
+  Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cmbCustomScriptTagsChange(Sender: TObject);
 begin
   cbUseCustomScriptTags.Checked := true;
   SetScriptTags(cmbCustomScriptTags.ItemIndex);
+  FForce := true;
   Eval;
 end;
 
@@ -336,7 +360,13 @@ begin
   try
     if FFilename <> '' then
       butSave.Enabled := true;
-    FTemplate := Template.Parse(FContext, memoTemplate.Lines.Text);
+
+    if FForce or (FLastContent <> memoTemplate.Lines.Text) then
+    begin
+      FTemplate := Template.Parse(FContext, memoTemplate.Lines.Text);
+      FLastContent := memoTemplate.Lines.Text;
+    end;
+
     Process;
     // this is a hack so that app does not throw an exception
     // during shutdown. it seems that the webbrowser must be visible
@@ -366,15 +396,22 @@ begin
   end
   else
     FEncoding := TEncoding.UTF8WithoutBOM;
+  FForce := true;
   Eval;
 end;
 
 procedure TFormTemplateEnginePlayground.cbShowWhitespaceClick(Sender: TObject);
 begin
   if cbShowWhitespace.Checked then
-    FContext.WhitespaceChar := #183
+  begin
+    if cbHtml.Checked then
+      FContext.WhitespaceChar := '&bull;'
+    else
+      FContext.WhitespaceChar := #183
+  end
   else
     FContext.WhitespaceChar := ' ';
+  FForce := true;
   Eval;
 end;
 
@@ -396,7 +433,7 @@ begin
   WebBrowser1.Enabled := true;
   tsGithubHelp.TabVisible := false;
   wbHelp.Enabled := false; // Doesn't work on github at this stage
-  //  wbHelp.Navigate('https://github.com/sempare/sempare-delphi-template-engine#Introduction');
+  // wbHelp.Navigate('https://github.com/sempare/sempare-delphi-template-engine#Introduction');
 {$IF defined(RELEASE)}
   FContext.MaxRunTimeMs := 5000;
 {$ENDIF}
@@ -453,7 +490,7 @@ begin
     '  ' + #13#10 + //
     ' If you like this project, please consider supporting enhancements via a commercial license which also entitles you to priority support.<p> ' + #13#10;
 
-  Finit := true;
+  FInit := true;
 end;
 
 procedure TFormTemplateEnginePlayground.GridPropsToContext;
@@ -519,7 +556,7 @@ var
   end;
 
 begin
-  if not Finit then
+  if not FInit then
     exit;
   GridPropsToContext;
   LPrettyOk := false;

--- a/src/Sempare.Template.AST.pas
+++ b/src/Sempare.Template.AST.pas
@@ -56,8 +56,7 @@ type
 
   TStripAction = ( //
     saWhitespace, //
-    saNL, //
-    saKeepOneSpace //
+    saNL //
     );
 
   TStripActionSet = set of TStripAction;
@@ -150,10 +149,8 @@ type
     vsBlock, //
 
     vsNewLine, //
-    vsWhiteSpace, //
+    vsWhiteSpace //
 
-    vsSingleton, //
-    vsValidate //
     );
 
   TTemplateSymbolSet = set of TTemplateSymbol;
@@ -201,9 +198,13 @@ type
     ['{8C539211-ED84-4963-B894-C569C2F7B2FE}']
   end;
 
+  TParserOption = (poAllowEnd, poAllowElse, poAllowElIf, poHasElse, poInLoop, poStripNL, poStripWS, poStripRecurringNL);
+  TParserOptions = set of TParserOption;
+
   IStmt = interface(ITemplateVisitorHost)
     ['{6D37028E-A0C0-41F1-8A59-EDC0C9ADD9C7}']
     function Flatten: TArray<IStmt>;
+    procedure OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string);
     function GetHasEnd: boolean;
     property HasEnd: boolean read GetHasEnd;
   end;
@@ -214,22 +215,19 @@ type
     property Stmt: IStmt read GetStmt;
   end;
 
-  TParserOption = (poAllowEnd, poAllowElse, poAllowElIf, poHasElse, poInLoop, poStripNL, poStripWS);
-  TParserOptions = set of TParserOption;
-
   ITemplate = interface(ITemplateVisitorHost)
     ['{93AAB971-5B4B-4959-93F2-6C7DAE15C91B}']
     function GetItem(const AOffset: integer): IStmt;
     function GetCount: integer;
     function GetLastItem: IStmt;
     procedure FlattenTemplate;
-    procedure OptimiseTemplate(const AOptions: TParserOptions);
+    procedure OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string);
     property Items[const AOffset: integer]: IStmt read GetItem;
     property Count: integer read GetCount;
     property LastItem: IStmt read GetLastItem;
   end;
 
-  TAddLocation = (alLast, alBeforeNL, alAfterNL);
+  TAddLocation = (alLast, alFront);
 
   ITemplateAdd = interface(ITemplate)
     ['{64465D68-0E9D-479F-9EF3-A30E75967809}']
@@ -260,7 +258,7 @@ type
     ['{FB4CC3AB-BFEC-4189-B555-153DDA490D15}']
   end;
 
-  TStripDirection = (sdEnd, sdLeft, sdRight, sdBeforeNewLine, sdAfterNewLine);
+  TStripDirection = (sdLeft, sdRight);
 
   IStripStmt = interface(IStmt)
     ['{3313745B-D635-4453-9808-660DC462E15C}']
@@ -366,6 +364,16 @@ type
     function GetExpr: IExpr;
     function GetContainer: ITemplate;
     property Expr: IExpr read GetExpr;
+    property Container: ITemplate read GetContainer;
+  end;
+
+  IIgnoreNLStmt = interface(IStmt)
+    function GetContainer: ITemplate;
+    property Container: ITemplate read GetContainer;
+  end;
+
+  IIgnoreWSStmt = interface(IStmt)
+    function GetContainer: ITemplate;
     property Container: ITemplate read GetContainer;
   end;
 
@@ -580,7 +588,10 @@ type
     procedure Visit(const AStmt: IBlockStmt); overload;
     procedure Visit(const AStmt: IExtendsStmt); overload;
     procedure Visit(const AStmt: ICompositeStmt); overload;
+    procedure Visit(const AStmt: INoopStmt); overload;
     procedure Visit(const AStmt: IStripStmt); overload;
+    procedure Visit(const AStmt: IIgnoreNLStmt); overload;
+    procedure Visit(const AStmt: IIgnoreWSStmt); overload;
   end;
 
   IEvaluationTemplateVisitor = interface(ITemplateVisitor)
@@ -614,6 +625,7 @@ type
   protected
     function Flatten: TArray<IStmt>; virtual;
     function GetHasEnd: boolean; virtual;
+    procedure OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string); virtual;
   public
     constructor Create(const APosition: IPosition);
   end;
@@ -632,12 +644,11 @@ type
 
 const
   StripDirectionStr: array [TStripDirection] of string = ( //
-    'sdEnd', 'sdLeft', 'sdRight', 'sdBeforeNewLine', 'sdAfterNewLine');
+    'sdLeft', 'sdRight' //
+    );
 
   StripActionStr: array [TStripAction] of string = ( //
-    'saWhitespace', //
-    'saNL', //
-    'saKeepOneSpace' //
+    'saWhitespace', 'saNL' //
     );
 
 type
@@ -742,6 +753,11 @@ end;
 function TAbstractStmt.GetHasEnd: boolean;
 begin
   exit(false);
+end;
+
+procedure TAbstractStmt.OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string);
+begin
+
 end;
 
 end.

--- a/src/Sempare.Template.Context.pas
+++ b/src/Sempare.Template.Context.pas
@@ -169,8 +169,8 @@ type
     procedure SetPrettyPrintOutput(const APrettyPrintOutput: TPrettyPrintOutput);
     function GetPrettyPrintOutput: TPrettyPrintOutput;
 
-    function GetWhitespace: char;
-    procedure SetWhiteSpace(const AWS: char);
+    function GetWhitespace: string;
+    procedure SetWhiteSpace(const AWS: string);
 
     function GetVariableResolver: TTemplateVariableResolver;
     procedure SetVariableResolver(const AResolver: TTemplateVariableResolver);
@@ -181,7 +181,7 @@ type
     property RttiContext: TGetRttiContext read GetRttiContext write SetRttiContext;
     property Functions: ITemplateFunctions read GetFunctions write SetFunctions;
     property NewLine: string read GetNewLine write SetNewLine;
-    property WhitespaceChar: char read GetWhitespace write SetWhiteSpace;
+    property WhitespaceChar: string read GetWhitespace write SetWhiteSpace;
     property TemplateResolver: TTemplateResolver read GetTemplateResolver write SetTemplateResolver;
     property TemplateResolverWithContext: TTemplateResolverWithContext read GetTemplateResolverWithContext write SetTemplateResolverWithContext;
     property MaxRunTimeMs: integer read GetMaxRunTimeMs write SetMaxRunTimeMs;
@@ -227,8 +227,6 @@ var
   GUTF8WithoutPreambleEncoding: TUTF8WithoutPreambleEncoding;
   GStreamWriterProvider: TStreamWriterProvider;
   GPrettyPrintOutput: TPrettyPrintOutput;
-  GDefaultOpenStripWSTag: string = '<|';
-  GDefaultCloseWSTag: string = '|>';
 
 implementation
 
@@ -286,7 +284,7 @@ type
     FFormatSettings: TFormatSettings;
     FDebugFormat: string;
     FPrettyPrintOutput: TPrettyPrintOutput;
-    FWhiteSpace: char;
+    FWhiteSpace: string;
     FVariableResolver: TTemplateVariableResolver;
     FRttiContext: TGetRttiContext;
   public
@@ -376,8 +374,8 @@ type
     function GetDebugErrorFormat: string;
     procedure SetDebugErrorFormat(const AFormat: string);
 
-    function GetWhitespace: char;
-    procedure SetWhiteSpace(const AWS: char);
+    function GetWhitespace: string;
+    procedure SetWhiteSpace(const AWS: string);
 
     function GetVariableResolver: TTemplateVariableResolver;
     procedure SetVariableResolver(const AResolver: TTemplateVariableResolver);
@@ -438,8 +436,6 @@ begin
   SetEncoding(GDefaultEncoding);
   FStartToken := GDefaultOpenTag;
   FEndToken := GDefaultCloseTag;
-  FStartStripToken := GDefaultOpenStripWSTag;
-  FEndStripToken := GDefaultCloseWSTag;
   FTemplates := TDictionary<string, ITemplate>.Create;
   FVariables := TTemplateVariables.Create;
   FFunctions := CreateTemplateFunctions(self);
@@ -579,7 +575,7 @@ begin
   exit(FVariables);
 end;
 
-function TTemplateContext.GetWhitespace: char;
+function TTemplateContext.GetWhitespace: string;
 begin
   exit(FWhiteSpace);
 end;
@@ -738,7 +734,7 @@ begin
   FVariableResolver := AResolver;
 end;
 
-procedure TTemplateContext.SetWhiteSpace(const AWS: char);
+procedure TTemplateContext.SetWhiteSpace(const AWS: string);
 begin
   FWhiteSpace := AWS;
 end;

--- a/src/Sempare.Template.Evaluate.pas
+++ b/src/Sempare.Template.Evaluate.pas
@@ -46,7 +46,8 @@ uses
   Sempare.Template.StackFrame,
   Sempare.Template.Common,
   Sempare.Template.Context,
-  Sempare.Template.Visitor;
+  Sempare.Template.Visitor,
+  Sempare.Template.Util;
 
 type
   ETemplateEval = class(ETemplate);
@@ -60,7 +61,7 @@ type
     FStackFrames: TObjectStack<TStackFrame>;
     FEvalStack: TStack<TValue>;
     FStream: TStream;
-    FStreamWriter: TStreamWriter;
+    FStreamWriter: TTemplateStreamWriter;
     FLoopOptions: TLoopOptions;
     FContext: ITemplateContext;
     FEvaluationContext: ITemplateEvaluationContext;
@@ -68,6 +69,7 @@ type
     FLocalTemplates: TDictionary<string, ITemplate>;
     FResolveContext: TTemplateValue;
     FTemplate: ITemplate;
+
     function HasBreakOrContinue: boolean; inline;
     function EncodeVariable(const AValue: TValue): TValue;
     procedure CheckRunTime(const APosition: IPosition);
@@ -120,6 +122,8 @@ type
     procedure Visit(const AStmt: IStripStmt); overload; override;
     procedure Visit(const AStmt: IBlockStmt); overload; override;
     procedure Visit(const AStmt: IExtendsStmt); overload; override;
+    procedure Visit(const AStmt: IIgnoreNLStmt); overload; override;
+    procedure Visit(const AStmt: IIgnoreWSStmt); overload; override;
   end;
 
 implementation
@@ -129,8 +133,7 @@ uses
   System.TypInfo, // needed for XE6 and below to access the TTypeKind variables
   Sempare.Template.BlockResolver,
   Sempare.Template.ResourceStrings,
-  Sempare.Template.Rtti,
-  Sempare.Template.Util;
+  Sempare.Template.Rtti;
 
 const
   LOOP_IDX_NAME: string = '_loop_idx_';
@@ -198,18 +201,22 @@ var
   LDerefKey: TValue;
   LDerefObj: TValue;
   LDerefedValue: TValue;
-  LAllowRootDeref: IPreserveValue<boolean>;
+  LAllowRootDeref: boolean;
 begin
-  LAllowRootDeref := Preserve.Value<boolean>(FAllowRootDeref, true);
+  LAllowRootDeref := FAllowRootDeref;
+  FAllowRootDeref := true;
+  try
+    LDerefObj := EvalExpr(AExpr.variable);
 
-  LDerefObj := EvalExpr(AExpr.variable);
-
-  LAllowRootDeref.SetValue(AExpr.DerefType = dtArray);
-  LDerefKey := EvalExpr(AExpr.DerefExpr);
-  LDerefedValue := Deref(AExpr, LDerefObj, LDerefKey, eoRaiseErrorWhenVariableNotFound in FContext.Options, FContext);
-  if LDerefedValue.IsType<TValue> then
-    LDerefedValue := LDerefedValue.AsType<TValue>();
-  FEvalStack.push(LDerefedValue);
+    FAllowRootDeref := AExpr.DerefType = dtArray;
+    LDerefKey := EvalExpr(AExpr.DerefExpr);
+    LDerefedValue := Deref(AExpr, LDerefObj, LDerefKey, eoRaiseErrorWhenVariableNotFound in FContext.Options, FContext);
+    if LDerefedValue.IsType<TValue> then
+      LDerefedValue := LDerefedValue.AsType<TValue>();
+    FEvalStack.push(LDerefedValue);
+  finally
+    FAllowRootDeref := LAllowRootDeref;
+  end;
 end;
 
 procedure TEvaluationTemplateVisitor.Visit(const AExpr: IBinopExpr);
@@ -345,7 +352,7 @@ end;
 
 procedure TEvaluationTemplateVisitor.Visit(const AStmt: IWhileStmt);
 var
-  LLoopOptions: IPreserveValue<TLoopOptions>;
+  LLoopOptions: TLoopOptions;
   LOffset: int64;
   LLimit: int64;
   i, LLoops: int64;
@@ -365,53 +372,58 @@ var
 begin
   if HasBreakOrContinue then
     exit;
-  LLoopOptions := Preserve.Value<TLoopOptions>(FLoopOptions, []);
-  FStackFrames.push(FStackFrames.peek.Clone);
-
-  LOffset := GetValue(AStmt.OffsetExpr);
-  LLimit := GetValue(AStmt.LimitExpr);
-
-  i := 0;
-  LLoops := 0;
-  LFirst := true;
+  LLoopOptions := FLoopOptions;
+  FLoopOptions := [];
   try
-    while ((LLimit = -1) or (LLoops < LLimit)) do
-    begin
-      if not EvalExprAsBoolean(AStmt.Condition) or (coBreak in FLoopOptions) then
-        break;
-      CheckRunTime(AStmt);
-      FStackFrames.peek[LOOP_IDX_NAME] := i;
-      if (LOffset = -1) or (i >= LOffset) then
+    FStackFrames.push(FStackFrames.peek.Clone);
+
+    LOffset := GetValue(AStmt.OffsetExpr);
+    LLimit := GetValue(AStmt.LimitExpr);
+
+    i := 0;
+    LLoops := 0;
+    LFirst := true;
+    try
+      while ((LLimit = -1) or (LLoops < LLimit)) do
       begin
-        if LFirst then
+        if not EvalExprAsBoolean(AStmt.Condition) or (coBreak in FLoopOptions) then
+          break;
+        CheckRunTime(AStmt);
+        FStackFrames.peek[LOOP_IDX_NAME] := i;
+        if (LOffset = -1) or (i >= LOffset) then
         begin
-          LFirst := false;
-          if AStmt.OnBeginContainer <> nil then
-            AcceptVisitor(AStmt.OnBeginContainer, self);
-        end
-        else
-        begin
-          if AStmt.BetweenItemsContainer <> nil then
-            AcceptVisitor(AStmt.BetweenItemsContainer, self);
+          if LFirst then
+          begin
+            LFirst := false;
+            if AStmt.OnBeginContainer <> nil then
+              AcceptVisitor(AStmt.OnBeginContainer, self);
+          end
+          else
+          begin
+            if AStmt.BetweenItemsContainer <> nil then
+              AcceptVisitor(AStmt.BetweenItemsContainer, self);
+          end;
+          exclude(FLoopOptions, coContinue);
+          AcceptVisitor(AStmt.Container, self);
+          inc(LLoops);
         end;
-        exclude(FLoopOptions, coContinue);
-        AcceptVisitor(AStmt.Container, self);
-        inc(LLoops);
+        inc(i);
       end;
-      inc(i);
+    finally
+      FStackFrames.pop;
+    end;
+    if LLoops = 0 then
+    begin
+      if AStmt.OnEmptyContainer <> nil then
+        AcceptVisitor(AStmt.OnEmptyContainer, self);
+    end
+    else
+    begin
+      if AStmt.OnEndContainer <> nil then
+        AcceptVisitor(AStmt.OnEndContainer, self);
     end;
   finally
-    FStackFrames.pop;
-  end;
-  if LLoops = 0 then
-  begin
-    if AStmt.OnEmptyContainer <> nil then
-      AcceptVisitor(AStmt.OnEmptyContainer, self);
-  end
-  else
-  begin
-    if AStmt.OnEndContainer <> nil then
-      AcceptVisitor(AStmt.OnEndContainer, self);
+    FLoopOptions := LLoopOptions;
   end;
 end;
 
@@ -437,7 +449,7 @@ end;
 
 procedure TEvaluationTemplateVisitor.Visit(const AStmt: IForInStmt);
 var
-  LLoopOptions: IPreserveValue<TLoopOptions>;
+  LLoopOptions: TLoopOptions;
   LVariableName: string;
   LLoopExpr: TValue;
   LLoopExprType: TRttiType;
@@ -646,53 +658,58 @@ var
 begin
   if HasBreakOrContinue then
     exit;
-  LLoopOptions := Preserve.Value<TLoopOptions>(FLoopOptions, []);
-  FStackFrames.push(FStackFrames.peek.Clone);
-  LVariableName := AStmt.variable;
-
-  LLoopExpr := EvalExpr(AStmt.Expr);
-  if LLoopExpr.IsType<TValue> then
-    LLoopExpr := LLoopExpr.AsType<TValue>();
-  LOffset := GetValue(AStmt.OffsetExpr);
-  LLimit := GetValue(AStmt.LimitExpr);
-
-  i := 0;
-  LLoops := 0;
-  LFirst := true;
+  LLoopOptions := FLoopOptions;
+  FLoopOptions := [];
   try
-    if not LLoopExpr.IsEmpty then
-    begin
-      LLoopExprType := FContext.RttiContext().GetType(LLoopExpr.TypeInfo);
+    FStackFrames.push(FStackFrames.peek.Clone);
+    LVariableName := AStmt.variable;
 
-      case LLoopExprType.TypeKind of
-        tkInterface:
-          VisitInterface;
-        tkRecord{$IFDEF SUPPORT_CUSTOM_MANAGED_RECORDS}, tkMRecord{$ENDIF}:
-          VisitRecord;
-        tkClass, tkClassRef:
-          VisitObject;
-        tkArray:
-          VisitArray;
-        tkDynArray:
-          VisitDynArray(AStmt.ForOp);
-        tkString, tkWString, tkLString, tkUString:
-          exit; // we return empty when there are issues, so lets ignore it
-      else
-        RaiseError(AStmt, SGetEnumeratorNotFoundOnObject);
+    LLoopExpr := EvalExpr(AStmt.Expr);
+    if LLoopExpr.IsType<TValue> then
+      LLoopExpr := LLoopExpr.AsType<TValue>();
+    LOffset := GetValue(AStmt.OffsetExpr);
+    LLimit := GetValue(AStmt.LimitExpr);
+
+    i := 0;
+    LLoops := 0;
+    LFirst := true;
+    try
+      if not LLoopExpr.IsEmpty then
+      begin
+        LLoopExprType := FContext.RttiContext().GetType(LLoopExpr.TypeInfo);
+
+        case LLoopExprType.TypeKind of
+          tkInterface:
+            VisitInterface;
+          tkRecord{$IFDEF SUPPORT_CUSTOM_MANAGED_RECORDS}, tkMRecord{$ENDIF}:
+            VisitRecord;
+          tkClass, tkClassRef:
+            VisitObject;
+          tkArray:
+            VisitArray;
+          tkDynArray:
+            VisitDynArray(AStmt.ForOp);
+          tkString, tkWString, tkLString, tkUString:
+            exit; // we return empty when there are issues, so lets ignore it
+        else
+          RaiseError(AStmt, SGetEnumeratorNotFoundOnObject);
+        end;
       end;
+    finally
+      FStackFrames.pop;
+    end;
+    if LLoops = 0 then
+    begin
+      if AStmt.OnEmptyContainer <> nil then
+        AcceptVisitor(AStmt.OnEmptyContainer, self);
+    end
+    else
+    begin
+      if AStmt.OnEndContainer <> nil then
+        AcceptVisitor(AStmt.OnEndContainer, self);
     end;
   finally
-    FStackFrames.pop;
-  end;
-  if LLoops = 0 then
-  begin
-    if AStmt.OnEmptyContainer <> nil then
-      AcceptVisitor(AStmt.OnEmptyContainer, self);
-  end
-  else
-  begin
-    if AStmt.OnEndContainer <> nil then
-      AcceptVisitor(AStmt.OnEndContainer, self);
+    FLoopOptions := LLoopOptions;
   end;
 end;
 
@@ -707,6 +724,7 @@ var
   LApply: ITemplateContextForScope;
 begin
   inherited Create();
+
   FTemplate := ATemplate;
   FResolveContext := AResolveContext;
   FAllowRootDeref := true;
@@ -723,7 +741,11 @@ begin
 
   FStream := AStream;
 
-  FStreamWriter := FContext.StreamWriterProvider(FStream, FContext);
+  FStreamWriter := TTemplateStreamWriter.Create(FContext.StreamWriterProvider(FStream, FContext));
+
+  if eoTrimLines in AContext.Options then
+    FStreamWriter.TrimLines := true;
+
   FEvalStack := TStack<TValue>.Create;
   FStackFrames := TObjectStack<TStackFrame>.Create;
   FStackFrames.push(AStackFrame);
@@ -811,7 +833,7 @@ procedure TEvaluationTemplateVisitor.Visit(const AStmt: IForRangeStmt);
 type
   TCompare = function(const ALow: integer; const AHigh: integer): boolean;
 var
-  LLoopOptions: IPreserveValue<TLoopOptions>;
+  LLoopOptions: TLoopOptions;
   LIdx: int64;
   LStartVal: int64;
   LEndVal: int64;
@@ -837,73 +859,78 @@ begin
   if HasBreakOrContinue then
     exit;
   LVariable := AStmt.variable;
-  LLoopOptions := Preserve.Value<TLoopOptions>(FLoopOptions, []);
-  LStartVal := EvalExprAsInt(AStmt.LowExpr);
-  LEndVal := EvalExprAsInt(AStmt.HighExpr);
-
-  LStep := GetValue(AStmt.StepExpr);
-  LFirst := true;
-  LDelta := 0;
-  LDirectionTestFunc := nil;
-  case AStmt.ForOp of
-    foTo:
-      begin
-        LDelta := 1;
-        LDirectionTestFunc := ForToCond;
-      end;
-    foDownto:
-      begin
-        LDelta := -1;
-        LDirectionTestFunc := ForDownToCond;
-      end
-  else
-    begin
-      RaiseErrorRes(AStmt, @STypeNotSupported);
-    end;
-  end;
-  if LStep <> -1 then
-  begin
-    LDelta := LDelta * abs(LStep);
-  end;
-  FStackFrames.push(FStackFrames.peek.Clone);
-  LIdx := LStartVal;
-  i := 0;
+  LLoopOptions := FLoopOptions;
+  FLoopOptions := [];
   try
-    while LDirectionTestFunc(LIdx, LEndVal) do
-    begin
-      FStackFrames.peek[LVariable] := LIdx;
-      FStackFrames.peek[LOOP_IDX_NAME] := i;
-      if coBreak in FLoopOptions then
-        break;
-      if LFirst then
+    LStartVal := EvalExprAsInt(AStmt.LowExpr);
+    LEndVal := EvalExprAsInt(AStmt.HighExpr);
+
+    LStep := GetValue(AStmt.StepExpr);
+    LFirst := true;
+    LDelta := 0;
+    LDirectionTestFunc := nil;
+    case AStmt.ForOp of
+      foTo:
+        begin
+          LDelta := 1;
+          LDirectionTestFunc := ForToCond;
+        end;
+      foDownto:
+        begin
+          LDelta := -1;
+          LDirectionTestFunc := ForDownToCond;
+        end
+    else
       begin
-        LFirst := false;
-        if AStmt.OnBeginContainer <> nil then
-          AcceptVisitor(AStmt.OnBeginContainer, self);
-      end
-      else
-      begin
-        if AStmt.BetweenItemsContainer <> nil then
-          AcceptVisitor(AStmt.BetweenItemsContainer, self);
+        RaiseErrorRes(AStmt, @STypeNotSupported);
       end;
-      exclude(FLoopOptions, coContinue);
-      CheckRunTime(AStmt);
-      AcceptVisitor(AStmt.Container, self);
-      inc(LIdx, LDelta);
-      inc(i);
+    end;
+    if LStep <> -1 then
+    begin
+      LDelta := LDelta * abs(LStep);
+    end;
+    FStackFrames.push(FStackFrames.peek.Clone);
+    LIdx := LStartVal;
+    i := 0;
+    try
+      while LDirectionTestFunc(LIdx, LEndVal) do
+      begin
+        FStackFrames.peek[LVariable] := LIdx;
+        FStackFrames.peek[LOOP_IDX_NAME] := i;
+        if coBreak in FLoopOptions then
+          break;
+        if LFirst then
+        begin
+          LFirst := false;
+          if AStmt.OnBeginContainer <> nil then
+            AcceptVisitor(AStmt.OnBeginContainer, self);
+        end
+        else
+        begin
+          if AStmt.BetweenItemsContainer <> nil then
+            AcceptVisitor(AStmt.BetweenItemsContainer, self);
+        end;
+        exclude(FLoopOptions, coContinue);
+        CheckRunTime(AStmt);
+        AcceptVisitor(AStmt.Container, self);
+        inc(LIdx, LDelta);
+        inc(i);
+      end;
+    finally
+      FStackFrames.pop;
+    end;
+    if i = 0 then
+    begin
+      if AStmt.OnEmptyContainer <> nil then
+        AcceptVisitor(AStmt.OnEmptyContainer, self);
+    end
+    else
+    begin
+      if AStmt.OnEndContainer <> nil then
+        AcceptVisitor(AStmt.OnEndContainer, self);
     end;
   finally
-    FStackFrames.pop;
-  end;
-  if i = 0 then
-  begin
-    if AStmt.OnEmptyContainer <> nil then
-      AcceptVisitor(AStmt.OnEmptyContainer, self);
-  end
-  else
-  begin
-    if AStmt.OnEndContainer <> nil then
-      AcceptVisitor(AStmt.OnEndContainer, self);
+    FLoopOptions := LLoopOptions;
   end;
 end;
 
@@ -1371,6 +1398,32 @@ begin
   end;
   LValue := TValue.From<IMapExpr>(LMapExpr);
   FEvalStack.push(LValue);
+end;
+
+procedure TEvaluationTemplateVisitor.Visit(const AStmt: IIgnoreWSStmt);
+var
+  LStripWS: boolean;
+begin
+  LStripWS := FStreamWriter.Stripws;
+  FStreamWriter.Stripws := true;
+  try
+    AcceptVisitor(AStmt.Container, self);
+  finally
+    FStreamWriter.Stripws := LStripWS;
+  end;
+end;
+
+procedure TEvaluationTemplateVisitor.Visit(const AStmt: IIgnoreNLStmt);
+var
+  LStripNL: boolean;
+begin
+  LStripNL := FStreamWriter.StripNL;
+  FStreamWriter.StripNL := true;
+  try
+    AcceptVisitor(AStmt.Container, self);
+  finally
+    FStreamWriter.StripNL := LStripNL;
+  end;
 end;
 
 end.

--- a/src/Sempare.Template.Functions.pas
+++ b/src/Sempare.Template.Functions.pas
@@ -385,11 +385,11 @@ var
 begin
   if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
     exit;
-  {$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
+{$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
   LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
-  {$ELSE}
+{$ELSE}
   LStackFrame := AStackFrames.ToArray[AStackFrames.count + AStackOffset];
-  {$ENDIF}
+{$ENDIF}
   LStackFrame[AVariable] := AValue;
 end;
 
@@ -706,11 +706,11 @@ var
 begin
   if (AStackFrames = nil) or (AStackFrames.count = 0) or (AStackOffset > 0) or (-AStackOffset > AStackFrames.count) then
     exit;
-  {$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
+{$IFDEF DEFINE SUPPORT_STACK_LIST_PROPERTY}
   LStackFrame := AStackFrames.List[AStackFrames.count + AStackOffset];
-  {$ELSE}
+{$ELSE}
   LStackFrame := AStackFrames.ToArray[AStackFrames.count + AStackOffset];
-  {$ENDIF}
+{$ENDIF}
   exit(LStackFrame[AVariable]);
 end;
 

--- a/src/Sempare.Template.JSON.pas
+++ b/src/Sempare.Template.JSON.pas
@@ -57,9 +57,9 @@ type
   TJsonArray = Data.DBXJSON.TJsonArray;
 {$ELSE}
   TJsonValue = System.JSON.TJsonValue;
-  {$IFDEF SUPPORT_JSON_BOOL}
+{$IFDEF SUPPORT_JSON_BOOL}
   TJSONBool = System.JSON.TJSONBool; // not in XE6
-  {$ENDIF}
+{$ENDIF}
   TJSONString = System.JSON.TJSONString;
   TJSONNumber = System.JSON.TJSONNumber;
   TJsonObject = System.JSON.TJsonObject;

--- a/src/Sempare.Template.PrettyPrint.pas
+++ b/src/Sempare.Template.PrettyPrint.pas
@@ -92,6 +92,9 @@ type
     procedure Visit(const AStmt: IBlockStmt); overload; override;
     procedure Visit(const AStmt: IExtendsStmt); overload; override;
 
+    procedure Visit(const AStmt: IIgnoreNLStmt); overload; override;
+    procedure Visit(const AStmt: IIgnoreWSStmt); overload; override;
+
   end;
 
 function BinOpToStr(const ASymbol: TBinOp): string;
@@ -610,6 +613,28 @@ end;
 procedure TPrettyPrintTemplateVisitor.Visit(const AExpr: IMapExpr);
 begin
   write(AExpr.GetMap.ToJson);
+end;
+
+procedure TPrettyPrintTemplateVisitor.Visit(const AStmt: IIgnoreWSStmt);
+begin
+  tab();
+  writeln('<%% ignorews %%>');
+  delta(4);
+  AcceptVisitor(AStmt.Container, self);
+  delta(-4);
+  tab();
+  writeln('<%% end %%>');
+end;
+
+procedure TPrettyPrintTemplateVisitor.Visit(const AStmt: IIgnoreNLStmt);
+begin
+  tab();
+  writeln('<%% ignorenl %%>');
+  delta(4);
+  AcceptVisitor(AStmt.Container, self);
+  delta(-4);
+  tab();
+  writeln('<%% end %%>');
 end;
 
 initialization

--- a/src/Sempare.Template.Rtti.pas
+++ b/src/Sempare.Template.Rtti.pas
@@ -1053,9 +1053,9 @@ begin
     (ATypeInfo = TypeInfo(TJSONNull)) or //
     (ATypeInfo = TypeInfo(TJSONNumber)) or //
     (ATypeInfo = TypeInfo(TJSONString)) or //
-    {$IFDEF SUPPORT_JSON_BOOL}
+{$IFDEF SUPPORT_JSON_BOOL}
     (ATypeInfo = TypeInfo(TJSONBool)) or //
-    {$ENDIF}
+{$ENDIF}
     (ATypeInfo = TypeInfo(TJSONTrue)) or //
     (ATypeInfo = TypeInfo(TJSONFalse)) //
     );

--- a/src/Sempare.Template.TemplateRegistry.pas
+++ b/src/Sempare.Template.TemplateRegistry.pas
@@ -71,7 +71,7 @@ type
     function GetCount: integer;
     function GetLastItem: IStmt;
     procedure FlattenTemplate;
-    procedure OptimiseTemplate(const AOptions: TParserOptions);
+    procedure OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string);
     procedure Accept(const AVisitor: ITemplateVisitor);
     function GetFilename: string;
     procedure SetFilename(const AFilename: string);
@@ -736,9 +736,9 @@ begin
   FTemplate.FlattenTemplate;
 end;
 
-procedure TAbstractProxyTemplate.OptimiseTemplate(const AOptions: TParserOptions);
+procedure TAbstractProxyTemplate.OptimiseTemplate(const AOptions: TParserOptions; const ANewLine: string);
 begin
-  FTemplate.OptimiseTemplate(AOptions);
+  FTemplate.OptimiseTemplate(AOptions, ANewLine);
 end;
 
 procedure TAbstractProxyTemplate.SetFilename(const AFilename: string);
@@ -794,11 +794,11 @@ begin
   except
     on e: Exception do
     begin
-    {$IFDEF DEBUG}
+{$IFDEF DEBUG}
       FTemplate := Template.Parse(Format('Error in %s: %s', [AFilename, e.message]));
-    {$ELSE}
+{$ELSE}
       FTemplate := Template.Parse(Format('Error in %s', [TPath.GetFilename(AFilename)]));
-    {$ENDIF}
+{$ENDIF}
     end;
   end;
   FTemplate.FileName := AFilename;

--- a/src/Sempare.Template.Util.pas
+++ b/src/Sempare.Template.Util.pas
@@ -36,48 +36,63 @@ interface
 
 uses
   System.Rtti,
+  System.Classes,
+  System.SysUtils,
   Sempare.Template.JSON,
   System.Generics.Collections;
 
 {$I 'Sempare.Template.Compiler.inc'}
 
-// This is copied from Sempare.Boot.Common.PreserveValue to make standalone.
 type
-  IPreserveValue<T> = interface
-
-    // A helper to allow a reference to be maintained
-    // so that the object does not get optimised out
-    procedure KeepAlive;
-    procedure SetValue(const AValue: T);
-    procedure NoReset; overload;
-    procedure NoReset(const AValue: T); overload;
-  end;
-
-type
-  Preserve = class
-  public
-    class function Value<T>(var AValue: T): IPreserveValue<T>; overload; static;
-    class function Value<T>(var AValue: T; const NewValue: T): IPreserveValue<T>; overload; static;
-  end;
-
-type
-
-  TPreserveValue<T> = class(TInterfacedObject, IPreserveValue<T>)
-  type
-    PT = ^T;
+  TTemplateStreamWriter = class(TTextWriter)
   private
-    FOldValue: T;
-    FValuePtr: PT;
-    FReset: boolean;
-  public
-    constructor Create(var AValue: T); overload;
-    constructor Create(var AValue: T; const NewValue: T); overload;
-    destructor Destroy; override;
+    FWriter: TStreamWriter;
+    FStripWS: boolean;
+    FStripNL: boolean;
+    FTrimLines: boolean;
+    FWS: string;
+    FLineBuffer: TStringBuilder;
+    procedure SetStripNL(const Value: boolean);
+    procedure SetStripWS(const Value: boolean);
+    procedure NotSupported;
 
-    procedure KeepAlive;
-    procedure SetValue(const AValue: T); inline;
-    procedure NoReset; overload;
-    procedure NoReset(const AValue: T); overload;
+  public
+    constructor Create(const AWriter: TStreamWriter); overload;
+    destructor Destroy; override;
+    procedure Close; override;
+    procedure Flush; override;
+    procedure OwnStream; inline;
+    procedure Write(Value: boolean); override;
+    procedure Write(Value: Char); override;
+    procedure Write(const Value: TCharArray); override;
+    procedure Write(Value: double); override;
+    procedure Write(Value: integer); override;
+    procedure Write(Value: int64); override;
+    procedure Write(Value: TObject); override;
+    procedure Write(Value: single); override;
+    procedure Write(const Value: string); override;
+    procedure Write(Value: Cardinal); override;
+    procedure Write(Value: UInt64); override;
+    procedure Write(const Format: string; Args: array of const); override;
+    procedure Write(const Value: TCharArray; Index, Count: integer); override;
+    procedure WriteLine; override;
+    procedure WriteLine(Value: boolean); override;
+    procedure WriteLine(Value: Char); override;
+    procedure WriteLine(const Value: TCharArray); override;
+    procedure WriteLine(Value: double); override;
+    procedure WriteLine(Value: integer); override;
+    procedure WriteLine(Value: int64); override;
+    procedure WriteLine(Value: TObject); override;
+    procedure WriteLine(Value: single); override;
+    procedure WriteLine(const Value: string); override;
+    procedure WriteLine(Value: Cardinal); override;
+    procedure WriteLine(Value: UInt64); override;
+    procedure WriteLine(const Format: string; Args: array of const); override;
+    procedure WriteLine(const Value: TCharArray; Index, Count: integer); override;
+
+    property StripWS: boolean read FStripWS write SetStripWS;
+    property StripNL: boolean read FStripNL write SetStripNL;
+    property TrimLines: boolean read FTrimLines write FTrimLines;
   end;
 
   TMap = record
@@ -121,8 +136,7 @@ uses
   Sempare.Template.Rtti,
   System.TypInfo,
   System.JSON,
-  System.Math,
-  System.SysUtils
+  System.Math
 {$IFDEF MSWINDOWS}
     , WinAPI.Windows
 {$IFDEF SUPPORT_WIN_REGISTRY}, System.Win.Registry{$ELSE}, Registry{$ENDIF};
@@ -182,61 +196,6 @@ begin
   exit(AHypervisorTime)
 end;
 {$ENDIF}
-{ TPreserveValue<T> }
-
-constructor TPreserveValue<T>.Create(var AValue: T);
-begin
-  FOldValue := AValue;
-  FValuePtr := @AValue;
-  FReset := True;
-end;
-
-constructor TPreserveValue<T>.Create(var AValue: T; const NewValue: T);
-begin
-  Create(AValue);
-  AValue := NewValue;
-end;
-
-procedure TPreserveValue<T>.SetValue(const AValue: T);
-begin
-  FValuePtr^ := AValue;
-end;
-
-destructor TPreserveValue<T>.Destroy;
-begin
-  if FReset then
-    SetValue(FOldValue);
-  inherited;
-end;
-
-procedure TPreserveValue<T>.KeepAlive;
-begin
-  // do nothing
-end;
-
-procedure TPreserveValue<T>.NoReset(const AValue: T);
-begin
-  NoReset();
-  SetValue(AValue);
-end;
-
-procedure TPreserveValue<T>.NoReset;
-begin
-  FReset := False;
-end;
-
-{ Preseve }
-
-class function Preserve.Value<T>(var AValue: T): IPreserveValue<T>;
-begin
-  exit(TPreserveValue<T>.Create(AValue));
-end;
-
-class function Preserve.Value<T>(var AValue: T; const NewValue: T): IPreserveValue<T>;
-begin
-  exit(TPreserveValue<T>.Create(AValue, NewValue));
-end;
-
 { TMap }
 
 function TMap.Add(const AKey: string; const AValue: TValue): boolean;
@@ -399,8 +358,8 @@ begin
 end;
 
 function TMap.ToJSON: string;
-  function ToExpr(const AValue: TValue): TJsonValue; forward;
-  function ToArray(const AValue: TArray<TValue>): TJsonArray; forward;
+function ToExpr(const AValue: TValue): TJsonValue; forward;
+function ToArray(const AValue: TArray<TValue>): TJsonArray; forward;
 
   function ToMap(const AMap: TMap): TJsonObject;
   var
@@ -463,7 +422,7 @@ var
 begin
   LObject := ToMap(self);
   try
-    exit(LObject.ToJson);
+    exit(LObject.ToJSON);
   finally
     LObject.Free;
   end;
@@ -500,6 +459,263 @@ begin
     end;
   end;
   exit(False);
+end;
+
+{ TTemplateStreamWriter }
+
+procedure TTemplateStreamWriter.Close;
+begin
+  Flush;
+  FWriter.Close;
+end;
+
+constructor TTemplateStreamWriter.Create(const AWriter: TStreamWriter);
+begin
+  inherited Create;
+  FWriter := AWriter;
+  FLineBuffer := TStringBuilder.Create;
+end;
+
+destructor TTemplateStreamWriter.Destroy;
+begin
+  FLineBuffer.Free;
+  FWriter.Free;
+  inherited;
+end;
+
+procedure TTemplateStreamWriter.Flush;
+begin
+  if FTrimLines then
+  begin
+    if FLineBuffer.length > 0 then
+    begin
+      var
+      Line := FLineBuffer.ToString.Trim;
+      FWriter.Write(Line);
+      FLineBuffer.Clear;
+    end;
+  end;
+  FWriter.Flush;
+end;
+
+procedure TTemplateStreamWriter.NotSupported;
+begin
+  raise ENotSupportedException.Create('TTemplateStreamWriter.Write');
+end;
+
+procedure TTemplateStreamWriter.OwnStream;
+begin
+  FWriter.OwnStream;
+end;
+
+procedure TTemplateStreamWriter.SetStripNL(const Value: boolean);
+begin
+  FStripNL := Value;
+  if Value then
+  begin // when we enable stripping, we preseve the old nl
+    FWS := FWriter.newline;
+    FWriter.newline := '';
+  end
+  else
+  begin
+    FWriter.newline := FWS;
+  end;
+end;
+
+procedure TTemplateStreamWriter.SetStripWS(const Value: boolean);
+begin
+  FStripWS := Value;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: Cardinal);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(const Value: string);
+var
+  LStartIdx, LEndIdx: integer;
+begin
+  if FTrimLines then
+  begin
+    LStartIdx := 1;
+    LEndIdx := 1;
+    while LEndIdx <= length(Value) do
+    begin
+      if CharInSet(Value[LEndIdx], [#10, #13]) then
+      begin
+        FWriter.Write(copy(Value, LStartIdx, LEndIdx - LStartIdx).Trim);
+        FWriter.Write(Value[LEndIdx]);
+        LStartIdx := LEndIdx + 1;
+      end;
+      Inc(LEndIdx);
+    end;
+
+    if LStartIdx <= length(Value) then
+    begin
+      FWriter.Write(copy(Value, LStartIdx, length(Value) - LStartIdx + 1).Trim);
+    end;
+  end
+  else
+  begin
+    if FStripWS or FStripNL then
+    begin
+      for var LChar in Value do
+        Write(LChar);
+    end
+    else
+    begin
+      FWriter.Write(Value);
+    end;
+  end;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: boolean);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(const Value: TCharArray; Index, Count: integer);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(const Format: string; Args: array of const);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: UInt64);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: Char);
+begin
+  if FTrimLines then
+  begin
+    FLineBuffer.Append(Value);
+    if Value = #10 then
+    begin
+      var
+      Line := FLineBuffer.ToString.Trim;
+      FWriter.Write(Line);
+      FLineBuffer.Clear;
+    end;
+  end
+  else
+  begin
+    case Value of
+      ' ', #9:
+        if FStripWS then
+          exit;
+      #10, #13:
+        if FStripNL then
+          exit;
+    end;
+    FWriter.Write(Value);
+  end;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: int64);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: TObject);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: single);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(const Value: TCharArray);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: double);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.Write(Value: integer);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(const Value: TCharArray);
+
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: double);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: integer);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine;
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: boolean);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: Char);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: int64);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: UInt64);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(const Format: string; Args: array of const);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(const Value: TCharArray; Index, Count: integer);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: Cardinal);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: TObject);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(Value: single);
+begin
+  NotSupported;
+end;
+
+procedure TTemplateStreamWriter.WriteLine(const Value: string);
+begin
+  NotSupported;
 end;
 
 initialization

--- a/src/Sempare.Template.Visitor.pas
+++ b/src/Sempare.Template.Visitor.pas
@@ -84,6 +84,8 @@ type
     procedure Visit(const AStmt: INoopStmt); overload; virtual;
     procedure Visit(const AStmt: IBlockStmt); overload; virtual;
     procedure Visit(const AStmt: IExtendsStmt); overload; virtual;
+    procedure Visit(const AStmt: IIgnoreNLStmt); overload; virtual;
+    procedure Visit(const AStmt: IIgnoreWSStmt); overload; virtual;
   end;
 
   TNoExprTemplateVisitor = class(TBaseTemplateVisitor, ITemplateVisitor)
@@ -335,6 +337,16 @@ end;
 procedure TBaseTemplateVisitor.Visit(const AStmt: INoopStmt);
 begin
 
+end;
+
+procedure TBaseTemplateVisitor.Visit(const AStmt: IIgnoreWSStmt);
+begin
+  AcceptVisitor(AStmt.Container, self);
+end;
+
+procedure TBaseTemplateVisitor.Visit(const AStmt: IIgnoreNLStmt);
+begin
+  AcceptVisitor(AStmt.Container, self);
 end;
 
 { TNoExprTemplateVisitor }

--- a/tests/Sempare.Template.Test.pas
+++ b/tests/Sempare.Template.Test.pas
@@ -242,53 +242,63 @@ procedure TTestTemplate.TestIgnoreNL;
 var
   LStringBuilder: TStringBuilder;
   LString, LResult: string;
-  LPreserveGlobalNL: IPreserveValue<string>;
+  LPreserveGlobalNL: string;
 begin
-  LPreserveGlobalNL := Preserve.Value<string>(GNewLine, #10);
-  LStringBuilder := TStringBuilder.Create;
+  LPreserveGlobalNL := GNewLine;
+  GNewLine := #10;
   try
-    LStringBuilder.append('hello ').append(#10);
-    LStringBuilder.append('world').append(#10);
-    LString := LStringBuilder.ToString;
+    LStringBuilder := TStringBuilder.Create;
+    try
+      LStringBuilder.append('hello ').append(#10);
+      LStringBuilder.append('world').append(#10);
+      LString := LStringBuilder.ToString;
+    finally
+      LStringBuilder.free;
+    end;
+
+    LResult := Template.Eval(LString);
+    Assert.AreEqual(LString, LResult);
+
+    LString := '<% ignorenl %>' + LString + '<%end%>';
+    LResult := Template.Eval(LString);
+    Assert.AreEqual('hello world', LResult);
   finally
-    LStringBuilder.free;
+    GNewLine := LPreserveGlobalNL;
   end;
-
-  LResult := Template.Eval(LString);
-  Assert.AreEqual(LString, LResult);
-
-  LString := '<% ignorenl %>' + LString + '<%end%>';
-  LResult := Template.Eval(LString);
-  Assert.AreEqual('hello world', LResult);
 end;
 
 procedure TTestTemplate.TestIgnoreNL2;
 var
   LStringBuilder: TStringBuilder;
   LString, LResult: string;
-  LPreserveGlobalNL: IPreserveValue<string>;
+  LPreserveGlobalNL: string;
 begin
-  LPreserveGlobalNL := Preserve.Value<string>(GNewLine, #10);
-  LStringBuilder := TStringBuilder.Create;
+  LPreserveGlobalNL := GNewLine;
+  GNewLine := #10;
   try
-    LStringBuilder.append('<table>').append(#10);
-    LStringBuilder.append('<tr>').append(#10);
-    LStringBuilder.append('<td>col1</td>').append(#10);
-    LStringBuilder.append('<td>col2</td>').append(#10);
-    LStringBuilder.append('</tr>').append(#10);
-    LStringBuilder.append('</table>').append(#10);
-    LString := LStringBuilder.ToString;
+    LStringBuilder := TStringBuilder.Create;
+    try
+      LStringBuilder.append('<table>').append(#10);
+      LStringBuilder.append('<tr>').append(#10);
+      LStringBuilder.append('<td>col1</td>').append(#10);
+      LStringBuilder.append('<td>col2</td>').append(#10);
+      LStringBuilder.append('</tr>').append(#10);
+      LStringBuilder.append('</table>').append(#10);
+      LString := LStringBuilder.ToString;
+    finally
+      LStringBuilder.free;
+    end;
+
+    LResult := Template.Eval(LString);
+
+    Assert.AreEqual(LString, LResult);
+
+    LString := '<% ignorenl %>' + LString + '<%end%>';
+    LResult := Template.Eval(LString, []);
+    Assert.AreEqual('<table><tr><td>col1</td><td>col2</td></tr></table>', LResult);
   finally
-    LStringBuilder.free;
+    GNewLine := LPreserveGlobalNL;
   end;
-
-  LResult := Template.Eval(LString);
-
-  Assert.AreEqual(LString, LResult);
-
-  LString := '<% ignorenl %>' + LString + '<%end%>';
-  LResult := Template.Eval(LString, []);
-  Assert.AreEqual('<table><tr><td>col1</td><td>col2</td></tr></table>', LResult);
 end;
 
 procedure TTestTemplate.TestList;

--- a/tests/Sempare.Template.TestLexer.pas
+++ b/tests/Sempare.Template.TestLexer.pas
@@ -171,20 +171,15 @@ end;
 
 procedure TTestTemplateLexer.TestStripCharLeftAndRight;
 begin
-  Assert.AreEqual('hello world', Template.Eval('<%- ''hello'' + '' '' + ''world'' -%>'));
-  Assert.AreEqual('hello world', Template.Eval('<%* ''hello'' + '' '' + ''world'' *%>'));
+  Assert.AreEqual('hello world', Template.Eval('<%- ''hello'' + '' '' + ''world'' %>'));
   Assert.AreEqual('123', Template.Eval('<%- 123%>'));
   Assert.AreEqual('-123', Template.Eval('<%- -123%>'));
 end;
 
 procedure TTestTemplateLexer.TestStripWhitespace;
 begin
-  Assert.AreEqual('helloworld    '#13#10, Template.Eval('hello    <%- "world" %>    '#13#10));
-  Assert.AreEqual('helloworld'#13#10, Template.Eval('hello    <%- "world" -%>    '#13#10));
-
-  Assert.AreEqual('hello world    '#13#10, Template.Eval('hello    <%+ "world" %>    '#13#10));
-  Assert.AreEqual('hello world ', { .  . } Template.Eval('hello    <%+ "world" +%>    '#13#10));
-  Assert.AreEqual('hello world', { .   . } Template.Eval('hello    <%+ "world" *%>    '#13#10));
+  Assert.AreEqual('helloworld', Template.Eval('hello    <%- "world" %>    '#13#10));
+  Assert.AreEqual('helloworld'#13#10, Template.Eval('hello    <%- "world" %>    '#13#10#13#10));
 end;
 
 procedure TTestTemplateLexer.TestUnicodeQuotedString;

--- a/tests/Sempare.Template.TestMap.pas
+++ b/tests/Sempare.Template.TestMap.pas
@@ -67,7 +67,7 @@ type
     [Test]
     procedure TestParseJson;
 
-    [test]
+    [Test]
     procedure TestMapWithExpression;
   end;
 

--- a/tests/Sempare.Template.TestNewLineOption.pas
+++ b/tests/Sempare.Template.TestNewLineOption.pas
@@ -55,8 +55,6 @@ type
     [Test]
     procedure TestStripLeft;
     [Test]
-    procedure TestStripRight;
-    [Test]
     procedure TestStripRecurringSpacesOption;
     [Test]
     procedure TestStripRecurringNewlineOption;
@@ -130,9 +128,7 @@ end;
 
 procedure TTestNewLineOption.TestStripLeft;
 begin
-  Assert.AreEqual('begin'#13#10'x  '#13#10'end', Template.Eval('begin'#13#10'   <%- "x" %>  '#13#10'end'));
-  Assert.AreEqual('begin x  '#13#10'end', Template.Eval('begin'#13#10'   <%+ "x" %>  '#13#10'end'));
-  Assert.AreEqual('beginx  '#13#10'end', Template.Eval('begin'#13#10'   <%* "x" %>  '#13#10'end'));
+  Assert.AreEqual('begin'#13#10'x'#13#10'end', Template.Eval('begin'#13#10'  <%- "x" %>     '#13#10#13#10'end'));
 end;
 
 procedure TTestNewLineOption.TestStripRecurringNewlineOption;
@@ -149,13 +145,6 @@ var
 begin
   LCtx := Template.Context([eoStripRecurringSpaces]);
   Assert.AreEqual('abc text text end', Template.Eval(LCtx, 'abc   text  text end'));
-end;
-
-procedure TTestNewLineOption.TestStripRight;
-begin
-  Assert.AreEqual('begin'#13#10'   x'#13#10'end', Template.Eval('begin'#13#10'   <% "x" -%>  '#13#10'end'));
-  Assert.AreEqual('begin'#13#10'   x end', Template.Eval('begin'#13#10'   <% "x" +%>  '#13#10'end'));
-  Assert.AreEqual('begin'#13#10'   xend', Template.Eval('begin'#13#10'   <% "x" *%>  '#13#10'end'));
 end;
 
 procedure TTestNewLineOption.TestTabsToSpacesOption;


### PR DESCRIPTION
whitespace support is simpler syntactically.

```
      <%- if true %>
     blah
      <% end %>
```

with the '-' immediately after the %, the following will be done:
- the whitespace just before the '<%- if' will be removed *1
- the whitespace up to the first newline just after the 'true %>' will be removed *2
- similar for before '<% end'  as per *1
- similar for after 'end %>' as per *2

#147